### PR TITLE
numdiff: document historical limit correctly

### DIFF
--- a/src/hatanaka/decompressor/io.rs
+++ b/src/hatanaka/decompressor/io.rs
@@ -7,11 +7,13 @@ use crate::{
 
 use std::io::{BufRead, BufReader, Lines, Read};
 
-/// [DecompressorIO] is a [Decompressor] implementation that works directly
-/// on any [Read]ble I/O interface. Use it if your application to decompress
-/// CRINEX to parsable RINEX efficiently. Refer to [Decompressor] for its
-/// limitations. It implements the same internal parameters as the historical
-/// CRX2RNX tool.
+/// [DecompressorIO] emplements [DecompressorExpert] internally and works
+/// directly on any [Read]able I/O interface.
+///
+/// Use it if your application to decompress CRINEX to readable RINEX efficiently.
+/// Refer to [Decompressor] for more information on the algorithm and the limitations.
+/// The historical CRX2RNX tool uses M=5 as the maximal compression order to ever be supported:
+/// this implementation uses the same setup.
 pub type DecompressorIO<R> = DecompressorExpertIO<5, R>;
 
 /// Unlike [DecompressorIO], [DecompressorExpertIO] is not limited in the decompression

--- a/src/hatanaka/decompressor/mod.rs
+++ b/src/hatanaka/decompressor/mod.rs
@@ -100,12 +100,19 @@ impl State {
     }
 }
 
-/// [DecompressorExpert] gives you full control over the maximal compression ratio.
-/// When decoding, we adapt to the compression ratio applied when the stream was encoded.
-/// RNX2CRX is historically limited to M<=3 while 5 is said to be the optimal.
-/// With [DecompressorExpert] you can support any value.
-/// Keep in mind that CRINEX is not a lossless compression for signal observations.
-/// The higher the compression order, the larger the error over the signal observations.
+/// [DecompressorExpert] is a structure to decompress CRINEX files.
+///
+/// The CRINEX file format supports mixing levels of compression in the same file, in
+/// anticipation of a clever compressor that adapts the compression level to the data.
+///
+/// The actual diff-order is read from the file; as
+/// long as it does not exceed M in this implementation, it will be decompressed correctly.
+///
+/// The sole member `M` is inherited from [NumDiff] and controls the maximum diff-order
+/// for decompressing numerical data.
+///
+/// The historical RNX2CRX program and our implementation only use a level of 3.
+/// This structure supports any M integer number.
 pub struct DecompressorExpert<const M: usize> {
     /// Whether this is a V3 parser or not
     v3: bool,

--- a/src/hatanaka/mod.rs
+++ b/src/hatanaka/mod.rs
@@ -1,11 +1,21 @@
-//! RINEX compression / decompression module
+//! RINEX compression and decompression module
 use thiserror::Error;
 
+/// The Hatanaka scheme performs higher-order numeric delta compression and
+/// textual diff compression on RINEX data. It produces ASCII output.
+/// The ASCII output should be further compressed with a general-purpose compressor
+/// (gzip, etc.)
+///
+/// It is lossless with regard to the data, but not to formatting ideosyncracies
+/// such as -.123 vs -0.123.
+///
+/// Hatanaka, Yuki (2008). "A Compression Format and Tools for GNSS Observation Data".
+/// Bulletin of the Geographical Survey Institute. 55: 21–30.
+/// https://www.gsi.go.jp/common/000045517.pdf
 // TODO
 // Improve Result<> IoError/Error relation ship
 // the current User API .read().error()
 // Will trigger a string comparison on every single .read() acces veritication
-
 mod compressor;
 mod crinex;
 mod decompressor;

--- a/src/hatanaka/numdiff.rs
+++ b/src/hatanaka/numdiff.rs
@@ -1,17 +1,25 @@
-//! Y. Hatanaka lossy Numerical compression algorithm
+//! Y. Hatanaka lossless numerical compression algorithm
 
-/// [NumDiff] is dedicated to numerical (de-)compression, following
-/// the algorithm developped by Y. Hatanaka. This compression
-/// is not lossless: the more efficient the data compression, the bigger the error.
-/// M specifies the maximal compression to ever be supported by the object.
-/// The compression level may vary freely during the object's lifetime, but exceeding M
-/// will cause a panic. Note that m = 5 was determined as best compromise.
-/// [NumDiff] does not support M>6!! it will panic in higher orders.
-/// Set M = 6 in your application (when building the object) and you'll be fine.
-/// Note that m=3 seems to be hardcoded in the historical RNX2CRX program.
-/// If you want to produce compatible data, you should respect that.
-/// Note that we support m<=(M=6), therefore if you remain within our application,
-/// you can use higher compression order.
+/// This module implements the Hatanaka scheme for numerical (de)-compression.
+/// Values are multiplied by a factor of 10^N (N is the number of decimals in the
+/// original data) to turn them into integers.
+/// These integers are then put through a higher-order delta-compression scheme.
+///
+/// There are two tunable parameters:
+/// - M: the maximum order accepted by the decompressor. The historical CRX2RNX
+///   program supports M=5, but we support M=6.
+/// - level (m): the actual order used for compression. It must be <= M. The
+///   historical RNX2CRX program uses m=3, which is a good choice for 1-30s
+///   sampling rates.
+///
+/// A higher m does not necessarily mean better compression, since at a high-enough
+/// level random noise dominates over any differential trend.
+///
+/// If you want to produce compatible data, you should respect M = 5.
+/// If your remain within our application, you can use higher compression order
+/// (m <= M = 6).
+///
+/// Currently compressor.rs uses level = 3 ([CompressorExpert::format()]).
 #[derive(Debug, Clone)]
 pub struct NumDiff<const M: usize> {
     /// iteration counter

--- a/src/hatanaka/textdiff.rs
+++ b/src/hatanaka/textdiff.rs
@@ -1,11 +1,13 @@
 //! Y. Hatanaka lossless TextDiff algorithm
 
-/// [TextDiff] is a structure that implements the Text diff. algorithm
-/// designed by Y. Hatanaka, which is a lossless text compression algorithm.
+/// [TextDiff] implements Hatakana's text differencing scheme,
+/// which improves compression of text data.
+///
 /// [TextDiff] in its current form does not allow compressing & decompressing (back & forth)
 /// at the same time: you need two dedicated objects.
-/// This does not bother our application because it only operates in one way,
-/// but it is one aspect to keep in mind.
+///
+/// This is not a limitation to the CRX2RNX decompression or RNX2CRNX compression
+/// algorithm, because they only work one way.
 #[derive(Debug)]
 pub struct TextDiff {
     buffer: String,


### PR DESCRIPTION
numdiff: document Hatanaka correctly
* Hatanaka is lossless. Did an LLM hallucinate this?
* Although rnx2crx uses `m` = 3, the accompanying crx2rnx program uses
  `M`` = 5 as the maximum level.
  This was explicitly mentioned in Hatanaka (2008) as a point of possible
  flexibility.
* The compression "expert" is not making use of a larger `m` either.
* A larger `m` is not necessarily better, see Hatanaka tables 3 & 4.
* Cite Hatanaka correctly.