### PR TITLE
Fixed errors when using feature "nav" due to hyperdual v1.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ obs = []
 nav = [
     "anise",
     "nalgebra",
-    "hyperdual"
+    "hyperdual",
 ]
 
 # Provides the special UT1-TAI methods

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ obs = []
 nav = [
     "anise",
     "nalgebra",
+    "hyperdual"
 ]
 
 # Provides the special UT1-TAI methods
@@ -157,8 +158,8 @@ maud = { version = "0.26", optional = true }
 rtcm-rs = { version = "0.11", optional = true }
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
 
-hyperdual = { version = "=1.4.0", optional = true }
-nalgebra = { version = "=0.34.0", optional = true }
+hyperdual = { version = "1.4", optional = true }
+nalgebra = { version = "0.34", optional = true }
 
 # Log is optional and our "debug" feature: use this if you're a dev.
 # Turn this on to obtain debug traces during parsing, formatting and calculations

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ version = "4.2"
 features = ["std"]
 
 [dependencies.anise]
-version = "0.9"
+version = "=0.9.6"
 optional = true
 
 [dependencies]
@@ -158,8 +158,8 @@ maud = { version = "0.26", optional = true }
 rtcm-rs = { version = "0.11", optional = true }
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
 
-hyperdual = { version = "1.4", optional = true }
-nalgebra = { version = "0.34", optional = true }
+hyperdual = { version = "=1.4.0", optional = true }
+nalgebra = { version = "=0.34.0", optional = true }
 
 # Log is optional and our "debug" feature: use this if you're a dev.
 # Turn this on to obtain debug traces during parsing, formatting and calculations

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ version = "4.2"
 features = ["std"]
 
 [dependencies.anise]
-version = "=0.9.6"
+version = "0.9"
 optional = true
 
 [dependencies]


### PR DESCRIPTION
Hyperdual 1.5.0 depends on nalgebra v0.34.0, thats why missmatched types errors appeared when using nav feature. The solution is to add hyperdual v1.4.0 to dependencies and use it in nav feature.