### PR TITLE
hatanaka: fix history buffer rotation in NumDiff

### DIFF
--- a/rinex/src/hatanaka/numdiff.rs
+++ b/rinex/src/hatanaka/numdiff.rs
@@ -48,7 +48,7 @@ impl<const M: usize> NumDiff<M> {
 
     /// Rotate internal buffer, take new sample into account.
     fn rotate_history(&mut self, data: i64) {
-        self.buf.copy_within(0..M - 2, 1);
+        self.buf.copy_within(0..M - 1, 1);
         self.buf[0] = data;
     }
 
@@ -152,5 +152,58 @@ mod test {
         assert_eq!(diff.compress(113483138205), -3150848442);
         assert_eq!(diff.compress(113469906136), 1575425367);
         assert_eq!(diff.compress(113457280090), 146);
+    }
+
+    #[test]
+    fn test_history_rotation_full_order() {
+        // Regression test for https://github.com/nav-solutions/rinex/issues/426
+        //
+        // `rotate_history` used to only shift `buf[0..M-2]`, so `buf[M-1]`
+        // (the oldest history slot) was frozen at its initial value forever
+        // and never took part in the running history. Decompression that
+        // reaches the maximal order `M` (as happens for the clock-offset
+        // field, which is decompressed with `NumDiff<5>` at order 5) then
+        // silently used a stale value instead of the correct one, causing
+        // decompression to diverge and eventually overflow further down
+        // the file.
+        //
+        // `compressed` below is the correct order-5 CRINEX encoding of
+        // `original`, computed independently of this crate. Decompressing
+        // it must reproduce `original` exactly, which requires every slot
+        // of the history buffer (including buf[M-1]) to stay up to date.
+        let original = [
+            126298057858_i64,
+            126282454570,
+            126267372371,
+            126252810509,
+            127814188268,
+            127800656941,
+            127787641437,
+            127775141621,
+            127762669477,
+        ];
+        let compressed = [
+            -15603288_i64,
+            521089,
+            -752,
+            1575420036,
+            -6301688027,
+            9452541607,
+            -6301698660,
+            1574937163,
+        ];
+
+        let mut diff = NumDiff::<5>::new(original[0], 5);
+
+        let mut recovered = vec![original[0]];
+        for value in compressed {
+            recovered.push(diff.decompress(value));
+        }
+
+        assert_eq!(
+            recovered, original,
+            "decompressed sequence diverged from the original: \
+             history rotation must keep every buffer slot (including buf[M-1]) up to date"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`NumDiff::rotate_history()` shifted only `buf[0..M-2]` into `buf[1..M-1]`,
leaving the last slot `buf[M-1]` untouched after construction. Any
`decompress()`/`compress()` call that reaches the maximal supported order
`M` (order 5 for the default `NumDiff<5>` used to decompress the CRINEX
clock offset field) then read that stale, never-updated slot instead of
the correct historical value.

Because Hatanaka differencing is stateful, the resulting error is not
self-correcting: it propagates into every following sample and grows
unbounded, eventually causing the reported `attempt to multiply with
overflow` panic deep into otherwise valid CRINEX V3 files that
legitimately reach that order.

The fix shifts `buf[0..M-1]` instead, so every slot of the history
buffer stays current.

## Out of scope

`NumDiff::compress()` has a separate, pre-existing limitation: it reads
one more history slot than `decompress()` for the same order, so
`compress()` at order `M` still indexes out of bounds. That is tracked
in \# 429 and intentionally not addressed here, since it does not affect
the decompression path reported in #426.

## Test plan

- Added `test_history_rotation_full_order`, a regression test that
  decompresses a synthetic order-5 sequence (ground truth computed
  independently of this crate) and checks the recovered values match.
  Confirmed it fails against the pre-fix code (values diverge, matching
  the divergence pattern that leads to the reported overflow) and passes
  after the fix.
- `cargo test -p rinex --lib hatanaka` passes.
- `cargo test -p rinex --lib` shows no new failures compared to `develop`
  (same pre-existing, unrelated `orbit_database_sanity` cascade failures
  in both cases).
- `rustfmt --check` on the changed file.
