### PR TITLE
hatanaka: make NumDiff::compress symmetric with decompress

### DIFF
--- a/rinex/src/hatanaka/numdiff.rs
+++ b/rinex/src/hatanaka/numdiff.rs
@@ -48,7 +48,7 @@ impl<const M: usize> NumDiff<M> {
 
     /// Rotate internal buffer, take new sample into account.
     fn rotate_history(&mut self, data: i64) {
-        self.buf.copy_within(0..M - 2, 1);
+        self.buf.copy_within(0..M - 1, 1);
         self.buf[0] = data;
     }
 
@@ -152,5 +152,58 @@ mod test {
         assert_eq!(diff.compress(113483138205), -3150848442);
         assert_eq!(diff.compress(113469906136), 1575425367);
         assert_eq!(diff.compress(113457280090), 146);
+    }
+
+    #[test]
+    fn test_history_rotation_full_order() {
+        // Regression test for https://github.com/nav-solutions/rinex/issues/426
+        //
+        // `rotate_history` used to only shift `buf[0..M-2]`, so `buf[M-1]`
+        // (the oldest history slot) was frozen at its initial value forever
+        // and never took part in the running history. Decompression that
+        // reaches the maximal order `M` (as happens for the clock-offset
+        // field, which is decompressed with `NumDiff<5>` at order 5) then
+        // silently used a stale value instead of the correct one, causing
+        // decompression to diverge and eventually overflow further down
+        // the file.
+        //
+        // `compressed` below is the correct order-5 CRINEX encoding of
+        // `original`, computed independently of this crate. Decompressing
+        // it must reproduce `original` exactly, which requires every slot
+        // of the history buffer (including buf[M-1]) to stay up to date.
+        let original = [
+            126298057858_i64,
+            126282454570,
+            126267372371,
+            126252810509,
+            127814188268,
+            127800656941,
+            127787641437,
+            127775141621,
+            127762669477,
+        ];
+        let compressed = [
+            -15603288_i64,
+            521089,
+            -752,
+            1575420036,
+            -6301688027,
+            9452541607,
+            -6301698660,
+            1574937163,
+        ];
+
+        let mut diff = NumDiff::<5>::new(original[0], 5);
+
+        let mut recovered = vec![original[0]];
+        for value in compressed {
+            recovered.push(diff.decompress(value));
+        }
+
+        assert_eq!(
+            recovered, original,
+            "decompressed sequence diverged from the original: \
+             history rotation must keep every buffer slot (including buf[M-1]) up to date"
+        );
     }
 }

--- a/rinex/src/hatanaka/numdiff.rs
+++ b/rinex/src/hatanaka/numdiff.rs
@@ -80,30 +80,35 @@ impl<const M: usize> NumDiff<M> {
     }
 
     /// Compresses input data point, returns "compressed" data point.
+    ///
+    /// The difference is computed against the history *before* the new
+    /// sample is pushed, exactly mirroring [Self::decompress]: order `m`
+    /// reads `buf[0..m]` in both directions, so a `NumDiff<M>` supports
+    /// orders up to `M` for compression and decompression alike.
     pub fn compress(&mut self, data: i64) -> i64 {
         if self.m < self.level {
             self.m += 1;
         }
-        self.rotate_history(data);
 
-        match self.m {
-            1 => self.buf[0] - self.buf[1],
-            2 => self.buf[0] - 2 * self.buf[1] + self.buf[2],
-            3 => self.buf[0] - 3 * self.buf[1] + 3 * self.buf[2] - self.buf[3],
-            4 => self.buf[0] - 4 * self.buf[1] + 6 * self.buf[2] - 4 * self.buf[3] + self.buf[4],
+        let compressed: i64 = match self.m {
+            1 => data - self.buf[0],
+            2 => data - 2 * self.buf[0] + self.buf[1],
+            3 => data - 3 * self.buf[0] + 3 * self.buf[1] - self.buf[2],
+            4 => data - 4 * self.buf[0] + 6 * self.buf[1] - 4 * self.buf[2] + self.buf[3],
             5 => {
-                self.buf[0] - 5 * self.buf[1] + 10 * self.buf[2] - 10 * self.buf[3]
-                    + 5 * self.buf[4]
-                    - self.buf[5]
+                data - 5 * self.buf[0] + 10 * self.buf[1] - 10 * self.buf[2] + 5 * self.buf[3]
+                    - self.buf[4]
             },
             6 => {
-                self.buf[0] - 6 * self.buf[1] + 15 * self.buf[2] - 20 * self.buf[3]
-                    + 15 * self.buf[4]
-                    - 6 * self.buf[5]
-                    + self.buf[6]
+                data - 6 * self.buf[0] + 15 * self.buf[1] - 20 * self.buf[2] + 15 * self.buf[3]
+                    - 6 * self.buf[4]
+                    + self.buf[5]
             },
             _ => panic!("numdiff is limited to M < 7"),
-        }
+        };
+
+        self.rotate_history(data);
+        compressed
     }
 }
 
@@ -205,5 +210,99 @@ mod test {
             "decompressed sequence diverged from the original: \
              history rotation must keep every buffer slot (including buf[M-1]) up to date"
         );
+    }
+
+    #[test]
+    fn test_compression_full_order() {
+        // Regression test for https://github.com/nav-solutions/rinex/issues/429
+        //
+        // `compress` used to rotate the history *before* differencing, so
+        // order `m` read `buf[0..=m]` while `decompress` only reads
+        // `buf[0..m]`. At the maximal order `M` this indexed `buf[M]`,
+        // one past the end of the buffer, and panicked.
+        //
+        // Same sequence as `test_history_rotation_full_order`: compressing
+        // `original` at order 5 with a `NumDiff<5>` must produce the
+        // independently computed `compressed` stream without panicking.
+        let original = [
+            126298057858_i64,
+            126282454570,
+            126267372371,
+            126252810509,
+            127814188268,
+            127800656941,
+            127787641437,
+            127775141621,
+            127762669477,
+        ];
+        let expected = [
+            -15603288_i64,
+            521089,
+            -752,
+            1575420036,
+            -6301688027,
+            9452541607,
+            -6301698660,
+            1574937163,
+        ];
+
+        let mut diff = NumDiff::<5>::new(original[0], 5);
+
+        let compressed: Vec<i64> = original[1..]
+            .iter()
+            .map(|value| diff.compress(*value))
+            .collect();
+
+        assert_eq!(compressed, expected);
+    }
+
+    #[test]
+    fn test_round_trip_full_order() {
+        // Compression and decompression must be exact inverses at every
+        // supported order, using the same `NumDiff<M>` size on both sides
+        // (order M with `NumDiff<M>` included). Exercises both re-init
+        // and the steady state past the ramp-up.
+        fn round_trip<const M: usize>(level: usize) {
+            let original: Vec<i64> = (0..4 * M as i64)
+                .map(|i| 126298057858 + i * i * 7919 - i * 15603288)
+                .collect();
+
+            let mut compressor = NumDiff::<M>::new(original[0], level);
+            let mut decompressor = NumDiff::<M>::new(original[0], level);
+
+            for value in &original[1..] {
+                let compressed = compressor.compress(*value);
+                let recovered = decompressor.decompress(compressed);
+                assert_eq!(
+                    recovered, *value,
+                    "round trip mismatch for M={} level={}",
+                    M, level
+                );
+            }
+
+            // reinit both kernels mid-stream and go again
+            compressor.force_init(original[0], level);
+            decompressor.force_init(original[0], level);
+
+            for value in &original[1..] {
+                let compressed = compressor.compress(*value);
+                let recovered = decompressor.decompress(compressed);
+                assert_eq!(
+                    recovered, *value,
+                    "round trip mismatch after force_init for M={} level={}",
+                    M, level
+                );
+            }
+        }
+
+        for level in 1..=3 {
+            round_trip::<3>(level);
+        }
+        for level in 1..=5 {
+            round_trip::<5>(level);
+        }
+        for level in 1..=6 {
+            round_trip::<6>(level);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #426 #429.

Stacked on #428: this branch contains that commit as well, since
compressing at order `M` needs the full history buffer that #428 repairs.
Only the top commit is new here. Merging #428 first will reduce this PR
to a single commit.

`NumDiff::compress()` rotated the history buffer *before* differencing,
so order `m` read `buf[0..=m]`, while `decompress()` computes first and
reads only `buf[0..m]`. A `NumDiff<M>` could therefore decompress at
order `M` but compressing at the same order indexed `buf[M]`, one past
the end of the buffer:

```
thread 'main' panicked at rinex/src/hatanaka/numdiff.rs:97:23:
index out of bounds: the len is 5 but the index is 5
```

The `level > 6` guard in `new()` / `force_init()` did not catch this
because it checks against the hard-coded ceiling of 6, not against `M`.

The fix computes the difference against the existing history and rotates
afterwards, mirroring `decompress()`. Both directions now read the same
slots for a given order, so a single `NumDiff<M>` supports orders up to
`M` for compression and decompression alike. Results are unchanged for
every order that previously worked.

## Test plan

- `test_compression_full_order`: compresses a 9-sample sequence at order 5
  with `NumDiff<5>` and checks the output against an independently
  computed reference stream. Panics with the index-out-of-bounds error on
  the old code, passes on the new code.
- `test_round_trip_full_order`: compress/decompress round trip with the
  same `NumDiff<M>` on both sides, for `M` in {3, 5, 6} and every order
  from 1 up to `M`, including a `force_init()` mid-stream. Panics on the
  old code as soon as the order reaches `M`, passes on the new code.
- The existing order-3 `test_compression` vectors still pass, confirming
  the rewrite is behaviour-preserving for previously supported orders.
- `cargo test -p rinex --lib hatanaka` passes.
- `cargo test -p rinex --lib` shows no new failures compared to `develop`
  (same pre-existing, unrelated `orbit_database_sanity` cascade failures
  in both cases).
- `rustfmt --check` on the changed file.
