### PR TITLE
navigation: write records that parse back in every revision

### DIFF
--- a/src/header/formatting.rs
+++ b/src/header/formatting.rs
@@ -33,6 +33,15 @@ impl Header {
         }
 
         self.format_comments(w)?;
+
+        if let Some(license) = &self.license {
+            writeln!(w, "{}", fmt_rinex(license, "LICENSE OF USE"))?;
+        }
+
+        if let Some(doi) = &self.doi {
+            writeln!(w, "{}", fmt_rinex(doi, "DOI"))?;
+        }
+
         self.format_rinex_dependent(w)?;
 
         if let Some(rcvr) = &self.rcvr {

--- a/src/navigation/earth_orientation.rs
+++ b/src/navigation/earth_orientation.rs
@@ -2,8 +2,12 @@
 
 use crate::{
     epoch::parse_in_timescale as parse_epoch_in_timescale,
+    error::FormattingError,
+    navigation::formatting::{format_epoch_v4_fields, NavFormatter},
     prelude::{Epoch, ParsingError, TimeScale},
 };
+
+use std::io::{BufWriter, Write};
 
 #[cfg(feature = "serde")]
 use serde::Serialize;
@@ -74,6 +78,43 @@ impl EarthOrientation {
                 delta_ut1,
             },
         ))
+    }
+
+    /// Formats the RINEX 4 EOP record (Table A34), following the
+    /// "> EOP" record header.
+    pub(crate) fn format_v4<W: Write>(
+        &self,
+        w: &mut BufWriter<W>,
+        epoch: Epoch,
+    ) -> Result<(), FormattingError> {
+        writeln!(
+            w,
+            "    {}{}{}{}",
+            format_epoch_v4_fields(epoch),
+            NavFormatter::new(self.x.0),
+            NavFormatter::new(self.x.1),
+            NavFormatter::new(self.x.2),
+        )?;
+
+        writeln!(
+            w,
+            "{:23}{}{}{}",
+            "",
+            NavFormatter::new(self.y.0),
+            NavFormatter::new(self.y.1),
+            NavFormatter::new(self.y.2),
+        )?;
+
+        writeln!(
+            w,
+            "    {}{}{}{}",
+            NavFormatter::new(self.t_tm as f64),
+            NavFormatter::new(self.delta_ut1.0),
+            NavFormatter::new(self.delta_ut1.1),
+            NavFormatter::new(self.delta_ut1.2),
+        )?;
+
+        Ok(())
     }
 }
 

--- a/src/navigation/ephemeris/formatting.rs
+++ b/src/navigation/ephemeris/formatting.rs
@@ -33,31 +33,39 @@ impl Ephemeris {
             },
         };
 
-        // starts with (clock_bias, drift, rate)
+        // starts with (clock_bias, drift, rate).
+        // SBAS messages carry the transmission time (seconds of week)
+        // in the drift rate slot, stored as the "week" orbit item.
         // epoch has already been buffered
+        let third = if sv_constellation == Constellation::SBAS {
+            self.get_orbit_f64("week").unwrap_or(self.clock_drift_rate)
+        } else {
+            self.clock_drift_rate
+        };
+
         write!(
             w,
             "{}{}{}",
             NavFormatter::new(self.clock_bias),
             NavFormatter::new(self.clock_drift),
-            NavFormatter::new(self.clock_drift_rate),
+            NavFormatter::new(third),
         )?;
+
+        // orbit lines: three leading blanks in RINEX 2, four from RINEX 3 on.
+        // Fields absent from the record are left blank, as the parser
+        // read them.
+        let padding = if version.major < 3 { "   " } else { "    " };
+        const BLANK: &str = "                   ";
 
         // following standard specs
         let data_fields = &standard_specs.items;
-        for i in 0..data_fields.len() {
-            if let Some(value) = self.get_orbit_f64(data_fields[i].0) {
-                if i % 4 == 0 {
-                    write!(w, "\n   {}", NavFormatter::new(value))?;
-                } else {
-                    write!(w, "{}", NavFormatter::new(value))?;
-                }
-            } else {
-                if i % 4 == 0 {
-                    write!(w, "\n   {}", NavFormatter::new(0.0))?;
-                } else {
-                    write!(w, "{}", NavFormatter::new(0.0))?;
-                }
+        for (i, (field, _)) in data_fields.iter().enumerate() {
+            if i % 4 == 0 {
+                write!(w, "\n{}", padding)?;
+            }
+            match self.get_orbit_f64(field) {
+                Some(value) => write!(w, "{}", NavFormatter::new(value))?,
+                None => write!(w, "{}", BLANK)?,
             }
         }
 
@@ -83,7 +91,6 @@ mod test {
     #[test]
     fn ephemeris_formatting() {
         let g01 = SV::from_str("G01").unwrap();
-        let version = Version::from_str("2.0").unwrap();
         let msgtype = NavMessageType::LNAV;
 
         let ephemeris = Ephemeris {
@@ -101,6 +108,9 @@ mod test {
             .collect(),
         };
 
+        // RINEX 2: orbit lines indented by three blanks,
+        // fields absent from the record left blank
+        let version = Version::from_str("2.0").unwrap();
         let utf8 = Utf8Buffer::new(1024);
         let mut writer = BufWriter::new(utf8);
 
@@ -109,19 +119,71 @@ mod test {
             .unwrap();
 
         let inner = writer.into_inner().unwrap();
-
         let utf8 = inner.to_ascii_utf8();
 
         assert_eq!(
             utf8,
             "-1.000000000000E-04-2.000000000000E-11 0.000000000000E+00
-    1.000000000000E+00 2.000000000000E+00 3.000000000000E+00 0.000000000000E+00
-    5.000000000000E+00 0.000000000000E+00 0.000000000000E+00 0.000000000000E+00
-    0.000000000000E+00 0.000000000000E+00 0.000000000000E+00 0.000000000000E+00
-    0.000000000000E+00 0.000000000000E+00 0.000000000000E+00 0.000000000000E+00
-    0.000000000000E+00 0.000000000000E+00 0.000000000000E+00 0.000000000000E+00
-    0.000000000000E+00 0.000000000000E+00 0.000000000000E+00 0.000000000000E+00
-    0.000000000000E+00 0.000000000000E+00\n"
+    1.000000000000E+00 2.000000000000E+00 3.000000000000E+00                   
+    5.000000000000E+00                                                         
+                                                                               
+                                                                               
+                                                                               
+                                                                               
+                                         \n"
         );
+
+        // RINEX 3: four blanks
+        let version = Version::from_str("3.0").unwrap();
+        let utf8 = Utf8Buffer::new(1024);
+        let mut writer = BufWriter::new(utf8);
+
+        ephemeris
+            .format(&mut writer, g01, version, msgtype)
+            .unwrap();
+
+        let inner = writer.into_inner().unwrap();
+        let utf8 = inner.to_ascii_utf8();
+
+        assert!(utf8.starts_with(
+            "-1.000000000000E-04-2.000000000000E-11 0.000000000000E+00
+     1.000000000000E+00 2.000000000000E+00 3.000000000000E+00                   
+     5.000000000000E+00"
+        ));
+    }
+
+    #[test]
+    fn sbas_ephemeris_formatting() {
+        // SBAS: the transmission time (seconds of week) is written
+        // in the clock drift rate slot
+        let s36 = SV::from_str("S36").unwrap();
+        let version = Version::from_str("3.0").unwrap();
+
+        let ephemeris = Ephemeris {
+            clock_bias: 0.0,
+            clock_drift: 0.0,
+            clock_drift_rate: 0.0,
+            orbits: [
+                ("week".to_string(), OrbitItem::U32(437280)),
+                ("satPosX".to_string(), OrbitItem::F64(42003.688)),
+            ]
+            .into_iter()
+            .collect(),
+        };
+
+        let utf8 = Utf8Buffer::new(1024);
+        let mut writer = BufWriter::new(utf8);
+
+        ephemeris
+            .format(&mut writer, s36, version, NavMessageType::LNAV)
+            .unwrap();
+
+        let inner = writer.into_inner().unwrap();
+        let utf8 = inner.to_ascii_utf8();
+
+        assert!(utf8.starts_with(
+            " 0.000000000000E+00 0.000000000000E+00 4.372800000000E+05
+     4.200368800000E+04"
+        ));
     }
 }

--- a/src/navigation/ephemeris/formatting.rs
+++ b/src/navigation/ephemeris/formatting.rs
@@ -43,12 +43,19 @@ impl Ephemeris {
             self.clock_drift_rate
         };
 
+        // RINEX 2 records use the 'D' exponent letter
+        let formatter = if version.major < 3 {
+            NavFormatter::new_v2
+        } else {
+            NavFormatter::new
+        };
+
         write!(
             w,
             "{}{}{}",
-            NavFormatter::new(self.clock_bias),
-            NavFormatter::new(self.clock_drift),
-            NavFormatter::new(third),
+            formatter(self.clock_bias),
+            formatter(self.clock_drift),
+            formatter(third),
         )?;
 
         // orbit lines: three leading blanks in RINEX 2, four from RINEX 3 on.
@@ -64,7 +71,7 @@ impl Ephemeris {
                 write!(w, "\n{}", padding)?;
             }
             match self.get_orbit_f64(field) {
-                Some(value) => write!(w, "{}", NavFormatter::new(value))?,
+                Some(value) => write!(w, "{}", formatter(value))?,
                 None => write!(w, "{}", BLANK)?,
             }
         }
@@ -108,7 +115,7 @@ mod test {
             .collect(),
         };
 
-        // RINEX 2: orbit lines indented by three blanks,
+        // RINEX 2: orbit lines indented by three blanks, 'D' exponent,
         // fields absent from the record left blank
         let version = Version::from_str("2.0").unwrap();
         let utf8 = Utf8Buffer::new(1024);
@@ -123,9 +130,9 @@ mod test {
 
         assert_eq!(
             utf8,
-            "-1.000000000000E-04-2.000000000000E-11 0.000000000000E+00
-    1.000000000000E+00 2.000000000000E+00 3.000000000000E+00                   
-    5.000000000000E+00                                                         
+            "-1.000000000000D-04-2.000000000000D-11 0.000000000000D+00
+    1.000000000000D+00 2.000000000000D+00 3.000000000000D+00                   
+    5.000000000000D+00                                                         
                                                                                
                                                                                
                                                                                

--- a/src/navigation/formatting.rs
+++ b/src/navigation/formatting.rs
@@ -1,12 +1,10 @@
-use itertools::Itertools;
-
 use std::io::{BufWriter, Write};
 
 use crate::{
     epoch::epoch_decompose as epoch_decomposition,
     error::FormattingError,
     navigation::{NavFrame, NavFrameType, NavKey, Record},
-    prelude::{Constellation, Header},
+    prelude::{Constellation, Epoch, Header},
 };
 
 pub(crate) struct NavFormatter {
@@ -118,37 +116,31 @@ fn format_epoch_v2v3<W: Write>(
     }
 }
 
+/// Formats the "yyyy mm dd hh mm ss" epoch of a RINEX 4 record.
+pub(crate) fn format_epoch_v4_fields(epoch: Epoch) -> String {
+    let (yyyy, m, d, hh, mm, ss, _) = epoch_decomposition(epoch);
+    format!(
+        "{:04} {:02} {:02} {:02} {:02} {:02}",
+        yyyy, m, d, hh, mm, ss
+    )
+}
+
+/// Formats the record header of a RINEX 4 record.
+/// The ephemeris epoch line follows, the other records write their
+/// own epoch line along with their data.
 fn format_epoch_v4<W: Write>(w: &mut BufWriter<W>, k: &NavKey) -> std::io::Result<()> {
-    let (yyyy, m, d, hh, mm, ss, _) = epoch_decomposition(k.epoch);
     match k.frmtype {
         NavFrameType::Ephemeris => {
             write!(
                 w,
-                "> EPH {:x} {}\n{:x} {:04} {:02} {:02} {:02} {:02} {:02}",
-                k.sv, k.msgtype, k.sv, yyyy, m, d, hh, mm, ss
+                "> EPH {:x} {}\n{:x} {}",
+                k.sv,
+                k.msgtype,
+                k.sv,
+                format_epoch_v4_fields(k.epoch)
             )
         },
-        NavFrameType::IonosphereModel => {
-            write!(
-                w,
-                "> ION {:x} {}\n        {:04} {:02} {:02} {:02} {:02} {:02}",
-                k.sv, k.msgtype, yyyy, m, d, hh, mm, ss
-            )
-        },
-        NavFrameType::SystemTimeOffset => {
-            write!(
-                w,
-                "> STO {:x} {}\n        {:04} {:02} {:02} {:02} {:02} {:02}",
-                k.sv, k.msgtype, yyyy, m, d, hh, mm, ss
-            )
-        },
-        NavFrameType::EarthOrientation => {
-            write!(
-                w,
-                "> EOP {:x} {}\n        {:04} {:02} {:02} {:02} {:02} {:02}",
-                k.sv, k.msgtype, yyyy, m, d, hh, mm, ss
-            )
-        },
+        frmtype => writeln!(w, "> {} {:x} {}", frmtype, k.sv, k.msgtype),
     }
 }
 
@@ -166,70 +158,28 @@ pub fn format<W: Write>(
         .constellation
         .ok_or(FormattingError::UndefinedConstellation)?;
 
-    // in chronological order
-    for epoch in rec.iter().map(|(k, _v)| k.epoch).unique().sorted() {
-        // per sorted constellations
-        for constell in rec
-            .iter()
-            .filter_map(|(k, _v)| {
-                if k.epoch == epoch {
-                    Some(k.sv.constellation)
-                } else {
-                    None
-                }
-            })
-            .unique()
-            .sorted()
-        {
-            // per sorted SV
-            for sv in rec
-                .iter()
-                .filter_map(|(k, _v)| {
-                    if k.epoch == epoch && k.sv.constellation == constell {
-                        Some(k.sv)
-                    } else {
-                        None
-                    }
-                })
-                .unique()
-                .sorted()
-            {
-                // per sorted frame type
-                for frmtype in rec
-                    .iter()
-                    .filter_map(|(k, _v)| {
-                        if k.epoch == epoch && k.sv == sv {
-                            Some(k.frmtype)
-                        } else {
-                            None
-                        }
-                    })
-                    .unique()
-                    .sorted()
-                {
-                    // format this entry
-                    if let Some((k, v)) = rec
-                        .iter()
-                        .filter(|(k, _v)| k.epoch == epoch && k.sv == sv && k.frmtype == frmtype)
-                        .reduce(|k, _| k)
-                    {
-                        // format epoch
-                        if v4 {
-                            format_epoch_v4(writer, k)?;
-                        } else {
-                            format_epoch_v2v3(writer, k, v2, &file_constell)?;
-                        }
-
-                        // format entry
-                        match v {
-                            NavFrame::EPH(eph) => eph.format(writer, k.sv, version, k.msgtype)?,
-                            _ => {},
-                        };
-                    }
-                }
+    // the record is sorted by key: chronological order, then vehicle,
+    // then message type. Every entry is written, including messages of
+    // different types sharing an epoch and vehicle.
+    for (k, v) in rec.iter() {
+        if v4 {
+            format_epoch_v4(writer, k)?;
+        } else {
+            match v {
+                NavFrame::EPH(_) => format_epoch_v2v3(writer, k, v2, &file_constell)?,
+                // no record representation before RINEX 4
+                _ => continue,
             }
         }
+
+        match v {
+            NavFrame::EPH(eph) => eph.format(writer, k.sv, version, k.msgtype)?,
+            NavFrame::STO(sto) => sto.format_v4(writer)?,
+            NavFrame::EOP(eop) => eop.format_v4(writer, k.epoch)?,
+            NavFrame::ION(model) => model.format_v4(writer, k.epoch)?,
+        }
     }
+
     Ok(())
 }
 
@@ -351,11 +301,8 @@ G01 2023 03 12 00 00 00"
 
         let utf8_ascii = inner.to_ascii_utf8();
 
-        assert_eq!(
-            &utf8_ascii,
-            "> ION G12 LNAV
-        2023 03 12 00 08 54"
-        );
+        // the model writes the epoch line along with its data
+        assert_eq!(&utf8_ascii, "> ION G12 LNAV\n");
     }
 
     #[test]
@@ -376,11 +323,7 @@ G01 2023 03 12 00 00 00"
 
         let utf8_ascii = inner.to_ascii_utf8();
 
-        assert_eq!(
-            &utf8_ascii,
-            "> STO C21 CNVX
-        2023 03 12 00 20 00"
-        );
+        assert_eq!(&utf8_ascii, "> STO C21 CNVX\n");
     }
 
     #[test]
@@ -401,10 +344,6 @@ G01 2023 03 12 00 00 00"
 
         let utf8_ascii = inner.to_ascii_utf8();
 
-        assert_eq!(
-            &utf8_ascii,
-            "> EOP G27 CNVX
-        2023 03 14 16 51 12"
-        );
+        assert_eq!(&utf8_ascii, "> EOP G27 CNVX\n");
     }
 }

--- a/src/navigation/formatting.rs
+++ b/src/navigation/formatting.rs
@@ -11,6 +11,8 @@ pub(crate) struct NavFormatter {
     value: f64,
     width: usize,
     precision: usize,
+    /// Exponent letter: 'E', or 'D' in RINEX 2 records
+    exponent: char,
 }
 
 impl NavFormatter {
@@ -19,6 +21,16 @@ impl NavFormatter {
             value,
             width: 15,
             precision: 12,
+            exponent: 'E',
+        }
+    }
+
+    /// Same formatting, with a 'D' exponent letter as found in
+    /// RINEX 2 navigation records.
+    pub fn new_v2(value: f64) -> Self {
+        Self {
+            exponent: 'D',
+            ..Self::new(value)
         }
     }
 
@@ -27,6 +39,7 @@ impl NavFormatter {
             value,
             width: 3,
             precision: 4,
+            exponent: 'E',
         }
     }
 
@@ -35,6 +48,7 @@ impl NavFormatter {
             value,
             width: 17,
             precision: 12,
+            exponent: 'E',
         }
     }
 
@@ -43,6 +57,7 @@ impl NavFormatter {
             value,
             width: 14,
             precision: 10,
+            exponent: 'E',
         }
     }
 
@@ -51,6 +66,7 @@ impl NavFormatter {
             value,
             width: 13,
             precision: 9,
+            exponent: 'E',
         }
     }
 }
@@ -77,7 +93,11 @@ impl std::fmt::Display for NavFormatter {
                 .parse::<i32>()
                 .unwrap();
             let formatted_exponent = format!("{}{:02}", exp_sign, exp_value);
-            write!(f, "{}{}E{}", sign_str, base, formatted_exponent)
+            write!(
+                f,
+                "{}{}{}{}",
+                sign_str, base, self.exponent, formatted_exponent
+            )
         } else {
             write!(f, "{}", formatted)
         }
@@ -95,11 +115,13 @@ fn format_epoch_v2v3<W: Write>(
     let decis = nanos / 100_000;
 
     if v2 && *file_constell != Constellation::Mixed {
+        // RINEX 2: PRN, two digit year, month, day, hour and minute
+        // as I2, seconds as F5.1
         write!(
             w,
-            "{:02} {:02} {:02} {:02} {:02} {:02} {:2}.{:01}",
+            "{:2} {:2} {:2} {:2} {:2} {:2} {:2}.{:01}",
             k.sv.prn,
-            yyyy - 2000,
+            yyyy % 100,
             m,
             d,
             hh,
@@ -207,6 +229,16 @@ mod test {
             let formatted = NavFormatter::new(value);
             assert_eq!(formatted.to_string(), expected);
         }
+
+        // RINEX 2 records: 'D' exponent
+        for (value, expected) in [
+            (0.0, " 0.000000000000D+00"),
+            (-1.0e-4, "-1.000000000000D-04"),
+            (5.153693731310e+03, " 5.153693731310D+03"),
+        ] {
+            let formatted = NavFormatter::new_v2(value);
+            assert_eq!(formatted.to_string(), expected);
+        }
     }
 
     #[test]
@@ -255,7 +287,7 @@ mod test {
 
         let utf8_ascii = inner.to_ascii_utf8();
 
-        assert_eq!(&utf8_ascii, "01 23 01 01 00 00  0.0");
+        assert_eq!(&utf8_ascii, " 1 23  1  1  0  0  0.0");
     }
 
     #[test]

--- a/src/navigation/ionosphere/bdgim.rs
+++ b/src/navigation/ionosphere/bdgim.rs
@@ -58,3 +58,42 @@ impl BdModel {
         Ok((epoch, Self { alpha }))
     }
 }
+
+impl BdModel {
+    /// Formats the RINEX 4 BDGIM ION record (Table A37).
+    pub(crate) fn format_v4<W: std::io::Write>(
+        &self,
+        w: &mut std::io::BufWriter<W>,
+        epoch: Epoch,
+    ) -> Result<(), crate::error::FormattingError> {
+        use crate::navigation::formatting::{format_epoch_v4_fields, NavFormatter};
+        use std::io::Write;
+
+        writeln!(
+            w,
+            "    {}{}{}{}",
+            format_epoch_v4_fields(epoch),
+            NavFormatter::new(self.alpha.0),
+            NavFormatter::new(self.alpha.1),
+            NavFormatter::new(self.alpha.2),
+        )?;
+
+        writeln!(
+            w,
+            "    {}{}{}{}",
+            NavFormatter::new(self.alpha.3),
+            NavFormatter::new(self.alpha.4),
+            NavFormatter::new(self.alpha.5),
+            NavFormatter::new(self.alpha.6),
+        )?;
+
+        writeln!(
+            w,
+            "    {}{}",
+            NavFormatter::new(self.alpha.7),
+            NavFormatter::new(self.alpha.8),
+        )?;
+
+        Ok(())
+    }
+}

--- a/src/navigation/ionosphere/klobuchar.rs
+++ b/src/navigation/ionosphere/klobuchar.rs
@@ -462,3 +462,42 @@ mod test {
         }
     }
 }
+
+impl KbModel {
+    /// Formats the RINEX 4 Klobuchar ION record (Table A35).
+    pub(crate) fn format_v4<W: std::io::Write>(
+        &self,
+        w: &mut std::io::BufWriter<W>,
+        epoch: Epoch,
+    ) -> Result<(), crate::error::FormattingError> {
+        use crate::navigation::formatting::{format_epoch_v4_fields, NavFormatter};
+        use std::io::Write;
+
+        writeln!(
+            w,
+            "    {}{}{}{}",
+            format_epoch_v4_fields(epoch),
+            NavFormatter::new(self.alpha.0),
+            NavFormatter::new(self.alpha.1),
+            NavFormatter::new(self.alpha.2),
+        )?;
+
+        writeln!(
+            w,
+            "    {}{}{}{}",
+            NavFormatter::new(self.alpha.3),
+            NavFormatter::new(self.beta.0),
+            NavFormatter::new(self.beta.1),
+            NavFormatter::new(self.beta.2),
+        )?;
+
+        writeln!(
+            w,
+            "    {}{}",
+            NavFormatter::new(self.beta.3),
+            NavFormatter::new(self.region as u8 as f64),
+        )?;
+
+        Ok(())
+    }
+}

--- a/src/navigation/ionosphere/mod.rs
+++ b/src/navigation/ionosphere/mod.rs
@@ -27,6 +27,21 @@ pub enum IonosphereModel {
     Bdgim(BdModel),
 }
 
+impl IonosphereModel {
+    /// Formats the RINEX 4 ION record, following the "> ION" record header.
+    pub(crate) fn format_v4<W: std::io::Write>(
+        &self,
+        w: &mut std::io::BufWriter<W>,
+        epoch: crate::prelude::Epoch,
+    ) -> Result<(), crate::error::FormattingError> {
+        match self {
+            Self::Klobuchar(model) => model.format_v4(w, epoch),
+            Self::NequickG(model) => model.format_v4(w, epoch),
+            Self::Bdgim(model) => model.format_v4(w, epoch),
+        }
+    }
+}
+
 impl Default for IonosphereModel {
     fn default() -> Self {
         Self::Klobuchar(KbModel::default())

--- a/src/navigation/ionosphere/nequick_g.rs
+++ b/src/navigation/ionosphere/nequick_g.rs
@@ -140,3 +140,28 @@ mod test {
         );
     }
 }
+
+impl NgModel {
+    /// Formats the RINEX 4 Nequick-G ION record (Table A36).
+    pub(crate) fn format_v4<W: std::io::Write>(
+        &self,
+        w: &mut std::io::BufWriter<W>,
+        epoch: Epoch,
+    ) -> Result<(), crate::error::FormattingError> {
+        use crate::navigation::formatting::{format_epoch_v4_fields, NavFormatter};
+        use std::io::Write;
+
+        writeln!(
+            w,
+            "    {}{}{}{}",
+            format_epoch_v4_fields(epoch),
+            NavFormatter::new(self.a.0),
+            NavFormatter::new(self.a.1),
+            NavFormatter::new(self.a.2),
+        )?;
+
+        writeln!(w, "    {}", NavFormatter::new(self.region.bits() as f64))?;
+
+        Ok(())
+    }
+}

--- a/src/navigation/time/formatting.rs
+++ b/src/navigation/time/formatting.rs
@@ -2,7 +2,10 @@ use crate::{
     epoch::epoch_decompose,
     error::FormattingError,
     fmt_rinex,
-    navigation::{formatting::NavFormatter, time::TimeOffset},
+    navigation::{
+        formatting::{format_epoch_v4_fields, NavFormatter},
+        time::TimeOffset,
+    },
     prelude::{Epoch, TimeScale},
 };
 
@@ -16,6 +19,7 @@ impl TimeOffset {
             (TimeScale::GPST, TimeScale::GST) => "GPGA",
             (TimeScale::GPST, TimeScale::BDT) => "GPBD",
             (TimeScale::QZSST, TimeScale::UTC) => "QZUT",
+            (TimeScale::QZSST, TimeScale::GPST) => "QZGP",
             (TimeScale::QZSST, TimeScale::GST) => "QZGA",
             (TimeScale::QZSST, TimeScale::BDT) => "QZBD",
             (TimeScale::GST, TimeScale::UTC) => "GAUT",
@@ -99,21 +103,25 @@ impl TimeOffset {
         Ok(())
     }
 
+    /// Formats the RINEX 4 STO record (Table A33), following the
+    /// "> STO" record header. The message transmission time is not
+    /// stored: the reference time (seconds of week) is written in its slot.
     pub(crate) fn format_v4<W: Write>(&self, w: &mut BufWriter<W>) -> Result<(), FormattingError> {
         let t = Epoch::from_time_of_week(self.t_ref.0, self.t_ref.1, self.lhs);
-        let (y, m, d, hh, mm, ss, _) = epoch_decompose(t);
 
-        writeln!(
+        write!(
             w,
-            "    {:04} {:02} {:02} {:02} {:02} {:02} {}",
-            y,
-            m,
-            d,
-            hh,
-            mm,
-            ss,
+            "    {} {}",
+            format_epoch_v4_fields(t),
             self.to_lhs_rhs_timescales(),
         )?;
+
+        // UTC identifier, column 63
+        if let Some(utc) = &self.utc {
+            write!(w, "{:34}{}", "", utc)?;
+        }
+
+        writeln!(w)?;
 
         writeln!(
             w,

--- a/src/navigation/time/parsing.rs
+++ b/src/navigation/time/parsing.rs
@@ -129,11 +129,16 @@ impl TimeOffset {
     /// Parse [TimeOffset] from RINEXv4 standard
     pub fn parse_v4(line_1: &str, line_2: &str) -> Result<Self, ParsingError> {
         let (epoch, rem) = line_1.split_at(24);
-        let (timescales, _) = rem.split_at(4);
+        let (timescales, rem) = rem.split_at(4);
 
         let (lhs, rhs) = Self::parse_lhs_rhs_timescales(timescales)?;
 
-        // let utc = rem.trim().to_string();
+        // UTC identifier (column 63), when the message defines one
+        let utc = match rem.trim() {
+            "" => None,
+            utc => Some(utc.to_string()),
+        };
+
         let t_ref = parse_epoch_in_timescale(epoch.trim(), lhs)?;
         let (t_week, t_nanos) = t_ref.to_time_of_week();
 
@@ -154,7 +159,8 @@ impl TimeOffset {
             parse_f64(a2.trim()).map_err(|_| ParsingError::NavTimeOffsetParinsg)?,
         );
 
-        let time_offset = Self::from_time_of_week(t_week, t_nanos, lhs, rhs, (a0, a1, a2));
+        let mut time_offset = Self::from_time_of_week(t_week, t_nanos, lhs, rhs, (a0, a1, a2));
+        time_offset.utc = utc;
 
         Ok(time_offset)
     }

--- a/src/tests/formatting/header.rs
+++ b/src/tests/formatting/header.rs
@@ -295,3 +295,24 @@ fn crinex_gal_v4_header_formatting() {
         ]),
     );
 }
+
+#[test]
+fn header_license_doi_formatting() {
+    let mut buf = BufWriter::new(Utf8Buffer::new(1024));
+
+    let mut header = Header::basic_obs()
+        .with_version(Version::new(4, 0))
+        .with_constellation(Constellation::GPS);
+
+    header.license = Some("CC BY 4.0".to_string());
+    header.doi = Some("https://doi.org/10.57677/BRD400DLR".to_string());
+
+    header.format(&mut buf).unwrap();
+
+    let content = buf.into_inner().unwrap().to_ascii_utf8();
+
+    let lines = content.lines().collect::<Vec<_>>();
+    assert!(lines
+        .contains(&"CC BY 4.0                                                   LICENSE OF USE"));
+    assert!(lines.contains(&"https://doi.org/10.57677/BRD400DLR                          DOI"));
+}

--- a/src/tests/formatting/mod.rs
+++ b/src/tests/formatting/mod.rs
@@ -46,3 +46,4 @@ pub fn generic_formatted_lines_test(utf8_content: &str, test_values: HashMap<usi
     }
     assert_eq!(nb_tests, total_tests);
 }
+pub mod nav;

--- a/src/tests/formatting/nav.rs
+++ b/src/tests/formatting/nav.rs
@@ -1,0 +1,121 @@
+//! Navigation RINEX formatting, compared to the original files.
+use crate::{navigation::NavFrameType, prelude::Rinex};
+
+use std::{collections::HashMap, fs::read_to_string, fs::remove_file};
+
+/// Splits a RINEX 4 navigation record section into blocks, one per
+/// "> XXX" record, keyed by the record header, the epoch and, for STO
+/// records, the time system pair. Exponent letters are uppercased and
+/// trailing blanks trimmed on every line.
+fn v4_record_blocks(content: &str) -> HashMap<String, Vec<String>> {
+    let mut blocks = HashMap::<String, Vec<String>>::new();
+    let mut header = Option::<String>::None;
+    let mut current = Option::<String>::None;
+
+    for line in content
+        .lines()
+        .skip_while(|line| !line.contains("END OF HEADER"))
+        .skip(1)
+    {
+        let line = line.trim_end().replace('e', "E");
+        if line.starts_with("> ") {
+            header = Some(line.clone());
+            current = None;
+            continue;
+        }
+        if let Some(header) = header.take() {
+            let key = if header.starts_with("> STO") {
+                format!("{}\n{}", header, &line[..28.min(line.len())])
+            } else {
+                format!("{}\n{}", header, &line[..23.min(line.len())])
+            };
+            blocks.insert(key.clone(), Vec::new());
+            current = Some(key);
+        }
+        if let Some(key) = &current {
+            if let Some(block) = blocks.get_mut(key) {
+                block.push(line);
+            }
+        }
+    }
+
+    blocks
+}
+
+/// Every STO, EOP and ION record written from `name` must be equal to
+/// the original text, and every such record of the parsed file must be
+/// written. Records sharing epoch, vehicle and message type overwrite
+/// each other in the record, so the original file may hold more.
+fn v4_records_write_back(name: &str) {
+    let path = format!("data/NAV/V4/{}", name);
+    let original = Rinex::from_gzip_file(&path).unwrap();
+
+    let tmp = format!("test-{}.rnx", name);
+    original.to_file(&tmp).unwrap();
+    let written = read_to_string(&tmp).unwrap();
+    let _ = remove_file(&tmp);
+
+    let original_text = {
+        let mut reader = flate2::read::GzDecoder::new(std::fs::File::open(&path).unwrap());
+        let mut content = String::new();
+        std::io::Read::read_to_string(&mut reader, &mut content).unwrap();
+        content
+    };
+
+    let model = v4_record_blocks(&original_text);
+    let dut = v4_record_blocks(&written);
+
+    let mut compared = 0;
+    for (key, written) in dut.iter() {
+        if key.starts_with("> EPH") {
+            continue;
+        }
+        let block = model
+            .get(key)
+            .unwrap_or_else(|| panic!("written record not in the original file:\n{}", key));
+
+        let (block, written) = if key.starts_with("> STO") {
+            // the message transmission time is not stored: the first
+            // field of the second line is not compared
+            (
+                vec![block[0].clone(), block[1][23..].to_string()],
+                vec![written[0].clone(), written[1][23..].to_string()],
+            )
+        } else if key.starts_with("> ION") && block.len() == 3 && block[2].len() == 23 {
+            // Klobuchar: a blank region code is read as worldwide (0)
+            // and written as such
+            let mut block = block.clone();
+            block[2].push_str(" 0.000000000000E+00");
+            (block, written.clone())
+        } else {
+            (block.clone(), written.clone())
+        };
+
+        assert_eq!(written, block, "record differs:\n{}", key);
+        compared += 1;
+    }
+
+    let expected = original
+        .record
+        .as_nav()
+        .unwrap()
+        .iter()
+        .filter(|(k, _)| k.frmtype != NavFrameType::Ephemeris)
+        .count();
+
+    assert_eq!(
+        compared, expected,
+        "not every STO, EOP or ION record written"
+    );
+    assert!(compared > 0, "no STO, EOP or ION record in {}", name);
+}
+
+#[test]
+fn nav_v4_kms300dnk_records_write_back() {
+    v4_records_write_back("KMS300DNK_R_20221591000_01H_MN.rnx.gz");
+}
+
+#[test]
+fn nav_v4_brd400dlr_records_write_back() {
+    v4_records_write_back("BRD400DLR_S_20230710000_01D_MN.rnx.gz");
+}

--- a/src/tests/production.rs
+++ b/src/tests/production.rs
@@ -146,7 +146,6 @@ fn nav_v3() {
 }
 
 #[test]
-#[ignore]
 fn nav_v4() {
     let folder = env!("CARGO_MANIFEST_DIR").to_owned() + "/data/NAV/V4/";
     for file in std::fs::read_dir(folder).unwrap() {

--- a/src/tests/toolkit/nav.rs
+++ b/src/tests/toolkit/nav.rs
@@ -166,8 +166,7 @@ pub fn generic_comparison(dut: &Rinex, model: &Rinex) {
 
     for (k, v) in model.iter() {
         if let Some(dut_v) = dut.get(&k) {
-            // TODO: add f64_eq verifications
-            // assert_eq!(v, dut_v);
+            assert_eq!(v, dut_v, "frame differs at {:?}", k);
         } else {
             panic!("missing data at {:?}", k);
         }


### PR DESCRIPTION
## Summary

Every navigation file written by the library was corrupt or lossy in some way. Four commits:

- `navigation: write ephemeris orbit lines the parser reads back`: orbit lines were indented by three blanks for every revision, while the RINEX 3 and 4 parsers skip four, so every written RINEX 3/4 file parsed back to shifted values. SBAS transmission times (kept as the `week` orbit item) were written as zero, and fields absent from the record were written as zero instead of blank. The navigation comparison of the test toolkit only checked key presence, which is why the round trips passed; it now compares the frames.
- `header: write the LICENSE OF USE and DOI lines`: parsed but never written (BRD400DLR carries a DOI).
- `navigation: write the RINEX 4 STO, EOP and ION records`: only ephemerides were written; other records got a header line without termination and no body, so records ran together and the file could not be parsed back. Records sharing epoch, vehicle and frame type (Galileo INAV/FNAV) were collapsed to one. The STO UTC identifier, discarded by the parser although the field exists, is kept.
- `navigation: write RINEX 2 records with I2 fields and a D exponent`: `01 23 01 01 00 00` instead of ` 1 23  1  1  0  0`, year as `yyyy - 2000`, and the `E` exponent of RINEX 3 where RINEX 2 files use `D`.

## Test plan

- Strict formatting round trips (parse, write, reparse, frames equal) of every navigation file of the data folder: `production::nav_v2`, `nav_v3`, and `nav_v4` which was ignored and is enabled.
- Every STO, EOP and ION record of the two RINEX 4 files is written back byte for byte (case of the exponent letter and trailing blanks aside; the STO transmission time is not stored and not compared).
- Unit tests for the ephemeris layout (RINEX 2 and 3, SBAS), the D exponent, the RINEX 2 epoch line, the RINEX 4 record header and the header lines.
- `cargo test --all-features` green at every commit (210 to 214 tests).

## Notes

- Not covered: writing a record in a revision other than the parsed one (RINEX 4 records as RINEX 3 and the reverse). That needs message type assignment and belongs with the RINEX 4.02 navigation changes.
- The RINEX 4 parser panics on truncated lines (`split_at` on short input); the writer fix removes the trigger, the parser is not hardened here.
- The STO transmission time is not stored by `TimeOffset`; the reference time (seconds of week) is written in its slot.
