### PR TITLE
observation: fix the signal validity checks

### DIFF
--- a/src/observation/signal.rs
+++ b/src/observation/signal.rs
@@ -52,25 +52,57 @@ impl SignalObservation {
     /// data when SNR or LLI are missing.
     pub fn is_ok(self) -> bool {
         let lli_ok = self.lli.unwrap_or(LliFlags::OK_OR_UNKNOWN) == LliFlags::OK_OR_UNKNOWN;
-        let snr_ok = self.snr.unwrap_or_default().strong();
+        let snr_ok = self.snr.map(|snr| snr.strong()).unwrap_or(true);
         lli_ok && snr_ok
     }
 
     /// [Observation::is_ok] with additional SNR criteria to match (>=).
     /// SNR must then be present otherwise this is not OK.
     pub fn is_ok_snr(&self, min_snr: SNR) -> bool {
-        if self
-            .lli
-            .unwrap_or(LliFlags::OK_OR_UNKNOWN)
-            .intersects(LliFlags::OK_OR_UNKNOWN)
-        {
-            if let Some(snr) = self.snr {
-                snr >= min_snr
-            } else {
-                false
-            }
-        } else {
-            false
-        }
+        let lli_ok = self.lli.unwrap_or(LliFlags::OK_OR_UNKNOWN) == LliFlags::OK_OR_UNKNOWN;
+        lli_ok && self.snr.map(|snr| snr >= min_snr).unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        observation::{LliFlags, SignalObservation, SNR},
+        prelude::{Observable, SV},
+    };
+    use std::str::FromStr;
+
+    #[test]
+    fn signal_validity() {
+        let g01 = SV::from_str("G01").unwrap();
+        let l1c = Observable::from_str("L1C").unwrap();
+
+        // no LLI, no SNR: OK, but not OK against a minimal SNR
+        let signal = SignalObservation::new(g01, l1c, 1.0);
+        assert!(signal.clone().is_ok());
+        assert!(!signal.is_ok_snr(SNR::DbHz30_35));
+
+        // strong SNR
+        let strong = signal.with_snr(SNR::DbHz36_41);
+        assert!(strong.clone().is_ok());
+        assert!(strong.is_ok_snr(SNR::DbHz30_35));
+        assert!(!strong.is_ok_snr(SNR::DbHz42_47));
+
+        // weak SNR
+        let weak = signal.with_snr(SNR::DbHz18_23);
+        assert!(!weak.clone().is_ok());
+        assert!(!weak.is_ok_snr(SNR::DbHz30_35));
+
+        // sane LLI flags
+        let mut flagged = strong.clone();
+        flagged.lli = Some(LliFlags::OK_OR_UNKNOWN);
+        assert!(flagged.clone().is_ok());
+        assert!(flagged.is_ok_snr(SNR::DbHz30_35));
+
+        // lock loss
+        let mut lock_loss = strong.clone();
+        lock_loss.lli = Some(LliFlags::LOCK_LOSS);
+        assert!(!lock_loss.clone().is_ok());
+        assert!(!lock_loss.is_ok_snr(SNR::DbHz30_35));
     }
 }


### PR DESCRIPTION
## Summary

Two validity checks of `SignalObservation` did not do what their documentation says:

- `is_ok()` rejected every signal without an SNR indication (the default SNR is the weakest level, never "strong"), although a missing SNR is documented as accepted. A missing SNR now passes; a reported one must still be strong.
- `is_ok_snr()` tested the LLI flags with `intersects()` against `OK_OR_UNKNOWN`, the empty flag set, so it returned false for every signal, whatever its SNR.

One commit, with a unit test covering signals without flags, strong and weak SNR, sane LLI flags and a lock loss.

## Test plan

- `cargo test --all-features` green (210 tests).
