### PR TITLE
navigation: write records in a revision other than the parsed one

### DIFF
--- a/db/NAV/orbits.json
+++ b/db/NAV/orbits.json
@@ -172,7 +172,8 @@
             "iscL5I5": "f64",
             "iscL5Q5": "f64",
             "t_tm": "f64",
-            "wn_op": "f64"
+            "wn_op": "f64",
+            "flags": "u8"
         }
     },
     {
@@ -215,7 +216,8 @@
             "spare1": "f64",
             "spare2": "f64",
             "t_tm": "f64",
-            "wn_op": "f64"
+            "wn_op": "f64",
+            "flags": "u8"
         }
     },
     {
@@ -511,7 +513,8 @@
             "iscL5I5": "f64",
             "iscL5Q5": "f64",
             "t_tm": "f64",
-            "wn_op": "f64"
+            "wn_op": "f64",
+            "flags": "u8"
         }
     },
     {
@@ -554,7 +557,8 @@
             "spare1": "f64",
             "spare2": "f64",
             "t_tm": "f64",
-            "wn_op": "f64"
+            "wn_op": "f64",
+            "flags": "u8"
         }
     },
     {

--- a/db/NAV/orbits.json
+++ b/db/NAV/orbits.json
@@ -831,5 +831,76 @@
             "accelZ": "f64",
             "iodn": "f64"
         }
+    },
+    {
+        "constellation": "IRNSS",
+        "version": {
+            "major": 3
+        },
+        "orbits": {
+            "iodec": "f64",
+            "crs": "f64",
+            "deltaN": "f64",
+            "m0": "f64",
+            "cuc": "f64",
+            "e": "f64",
+            "cus": "f64",
+            "sqrta": "f64",
+            "toe": "f64",
+            "cic": "f64",
+            "omega0": "f64",
+            "cis": "f64",
+            "i0": "f64",
+            "crc": "f64",
+            "omega": "f64",
+            "omegaDot": "f64",
+            "idot": "f64",
+            "spare1": "f64",
+            "week": "u32",
+            "spare2": "f64",
+            "accuracy": "f64",
+            "health": "flag",
+            "tgd": "f64",
+            "spare3": "f64",
+            "t_tm": "f64"
+        }
+    },
+    {
+        "constellation": "IRNSS",
+        "version": {
+            "major": 4
+        },
+        "type": "L1NV",
+        "orbits": {
+            "adot": "f64",
+            "crs": "f64",
+            "deltaN0": "f64",
+            "m0": "f64",
+            "cuc": "f64",
+            "e": "f64",
+            "cus": "f64",
+            "sqrta": "f64",
+            "iodec": "f64",
+            "cic": "f64",
+            "omega0": "f64",
+            "cis": "f64",
+            "i0": "f64",
+            "crc": "f64",
+            "omega": "f64",
+            "omegaDot": "f64",
+            "idot": "f64",
+            "deltaN0Dot": "f64",
+            "spare1": "f64",
+            "rsf": "f64",
+            "urai": "f64",
+            "health": "flag",
+            "tgdL1PL5": "f64",
+            "tgdSL5": "f64",
+            "iscSL1P": "f64",
+            "iscL1DL1P": "f64",
+            "iscL1PS": "f64",
+            "iscL1DS": "f64",
+            "t_tm": "f64"
+        }
     }
 ]

--- a/db/NAV/orbits.json
+++ b/db/NAV/orbits.json
@@ -902,5 +902,87 @@
             "iscL1DS": "f64",
             "t_tm": "f64"
         }
+    },
+    {
+        "constellation": "GLO",
+        "version": {
+            "major": 4
+        },
+        "type": "L1OC",
+        "orbits": {
+            "satPosX": "f64",
+            "velX": "f64",
+            "accelX": "f64",
+            "health": "flag",
+            "satPosY": "f64",
+            "velY": "f64",
+            "accelY": "f64",
+            "dataValidity": "u8",
+            "satPosZ": "f64",
+            "velZ": "f64",
+            "accelZ": "f64",
+            "tgdL2OCp": "f64",
+            "satType": "u8",
+            "sourceFlags": "u8",
+            "aode": "f64",
+            "aodc": "f64",
+            "attitudeFlag": "u8",
+            "tin": "f64",
+            "tau1": "f64",
+            "tau2": "f64",
+            "yawAngle": "f64",
+            "signFlag": "f64",
+            "angularRate": "f64",
+            "angularAccel": "f64",
+            "maxAngularRate": "f64",
+            "pcX": "f64",
+            "pcY": "f64",
+            "pcZ": "f64",
+            "uraiOrb": "f64",
+            "uraiClk": "f64",
+            "spare1": "f64",
+            "t_tm": "f64"
+        }
+    },
+    {
+        "constellation": "GLO",
+        "version": {
+            "major": 4
+        },
+        "type": "L3OC",
+        "orbits": {
+            "satPosX": "f64",
+            "velX": "f64",
+            "accelX": "f64",
+            "health": "flag",
+            "satPosY": "f64",
+            "velY": "f64",
+            "accelY": "f64",
+            "dataValidity": "u8",
+            "satPosZ": "f64",
+            "velZ": "f64",
+            "accelZ": "f64",
+            "iscL3OCp": "f64",
+            "satType": "u8",
+            "sourceFlags": "u8",
+            "aode": "f64",
+            "aodc": "f64",
+            "attitudeFlag": "u8",
+            "tin": "f64",
+            "tau1": "f64",
+            "tau2": "f64",
+            "yawAngle": "f64",
+            "signFlag": "f64",
+            "angularRate": "f64",
+            "angularAccel": "f64",
+            "maxAngularRate": "f64",
+            "pcX": "f64",
+            "pcY": "f64",
+            "pcZ": "f64",
+            "uraiOrb": "f64",
+            "uraiClk": "f64",
+            "spare1": "f64",
+            "t_tm": "f64"
+        }
     }
 ]

--- a/src/carrier.rs
+++ b/src/carrier.rs
@@ -336,21 +336,21 @@ impl Carrier {
         }
     }
 
-    pub(crate) fn gpsl1_codes() -> [&'static str; 40] {
+    pub(crate) fn gpsl1_codes() -> [&'static str; 44] {
         [
             "C1", "L1", "D1", "S1", "P1", "C1C", "L1C", "D1C", "S1C", "C1S", "L1S", "D1S", "S1S",
             "C1L", "L1L", "D1L", "S1L", "C1X", "L1X", "D1X", "S1X", "C1P", "L1P", "D1P", "S1P",
             "C1W", "L1W", "D1W", "S1W", "C1Y", "L1Y", "D1Y", "S1Y", "C1M", "L1M", "D1M", "S1M",
-            "L1N", "D1N", "S1N",
+            "L1N", "D1N", "S1N", "C1R", "L1R", "D1R", "S1R",
         ]
     }
 
-    pub(crate) fn gpsl2_codes() -> [&'static str; 44] {
+    pub(crate) fn gpsl2_codes() -> [&'static str; 48] {
         [
             "C2", "L2", "D2", "S2", "P2", "C2C", "L2C", "D2C", "S2C", "C2D", "L2D", "D2D", "S2D",
             "C2S", "L2S", "D2S", "S2S", "C2L", "L2L", "D2L", "S2L", "C2X", "L2X", "D2X", "S2X",
             "C2P", "L2P", "D2P", "S2P", "C2W", "L2W", "D2W", "S2W", "C2Y", "L2Y", "D2Y", "S2Y",
-            "C2M", "L2M", "D2M", "S2M", "L2N", "D2N", "S2N",
+            "C2M", "L2M", "D2M", "S2M", "L2N", "D2N", "S2N", "C2R", "L2R", "D2R", "S2R",
         ]
     }
 
@@ -667,6 +667,13 @@ impl Carrier {
         }
     }
 
+    /// NavIC L1 codes (RINEX 4.01)
+    pub(crate) fn irnl1_codes() -> [&'static str; 12] {
+        [
+            "C1D", "L1D", "D1D", "S1D", "C1P", "L1P", "D1P", "S1P", "C1X", "L1X", "D1X", "S1X",
+        ]
+    }
+
     pub(crate) fn irnl5_codes() -> [&'static str; 20] {
         [
             "C5", "L5", "D5", "S5", "C5A", "L5A", "D5A", "S5A", "C5B", "L5B", "D5B", "S5B", "C5C",
@@ -688,7 +695,9 @@ impl Carrier {
             | Observable::SSI(code)
             | Observable::PseudoRange(code) => {
                 let code = code.as_str();
-                if Self::irnl5_codes().contains(&code) {
+                if Self::irnl1_codes().contains(&code) {
+                    Ok(Self::L1)
+                } else if Self::irnl5_codes().contains(&code) {
                     Ok(Self::L5)
                 } else if Self::irn_s_codes().contains(&code) {
                     Ok(Self::S)
@@ -794,6 +803,28 @@ impl Carrier {
 mod test {
     use super::*;
     use std::str::FromStr;
+
+    #[test]
+    fn rinex_4_01_observation_codes() {
+        // GPS L1/L2 "R" attribute and NavIC L1 codes, added by RINEX 4.01
+        for (constellation, code, carrier) in [
+            (Constellation::GPS, "L1R", Carrier::L1),
+            (Constellation::GPS, "C2R", Carrier::L2),
+            (Constellation::IRNSS, "C1D", Carrier::L1),
+            (Constellation::IRNSS, "L1P", Carrier::L1),
+            (Constellation::IRNSS, "S1X", Carrier::L1),
+            (Constellation::IRNSS, "C5A", Carrier::L5),
+        ] {
+            let observable = Observable::from_str(code).unwrap();
+            assert_eq!(
+                Carrier::from_observable(constellation, &observable).unwrap(),
+                carrier,
+                "{:?} {}",
+                constellation,
+                code
+            );
+        }
+    }
 
     #[test]
     fn test_carrier() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -188,6 +188,9 @@ pub enum ParsingError {
     #[error("nav: invalid message type")]
     NavMsgType,
 
+    #[error("nav: invalid message subtype")]
+    NavMsgSubtype,
+
     #[error("nav: (ref) epoch week counter parsing")]
     NavEpochWeekCounter,
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -227,6 +227,12 @@ pub enum ParsingError {
     #[error("nav:ion bdgim data")]
     BdgimData,
 
+    #[error("nav:ion navic data")]
+    NavicIonosphereData,
+
+    #[error("nav:ion glonass cdma data")]
+    GlonassIonosphereData,
+
     #[error("nav:sto data")]
     SystemTimeData,
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -296,6 +296,9 @@ pub enum FormattingError {
 
     #[error("crinex compression: {0}")]
     Hatanaka(#[from] HatanakaError),
+
+    #[error("nav: no frame can be written in this revision")]
+    NoRepresentableFrame,
 }
 
 /// General error (processing, analysis..)

--- a/src/navigation/ephemeris/formatting.rs
+++ b/src/navigation/ephemeris/formatting.rs
@@ -10,6 +10,19 @@ use crate::{
 
 use std::io::{BufWriter, Write};
 
+/// The BeiDou group delays are named differently by the RINEX 3 and
+/// RINEX 4 orbit definitions: a record parsed in one revision is written
+/// in the other under either name.
+fn orbit_alias(key: &str) -> Option<&'static str> {
+    match key {
+        "tgdb1b3" => Some("tgd1b1b3"),
+        "tgd1b1b3" => Some("tgdb1b3"),
+        "tgdb2b3" => Some("tgd2b2b3"),
+        "tgd2b2b3" => Some("tgdb2b3"),
+        _ => None,
+    }
+}
+
 impl Ephemeris {
     /// Formats [Ephemeris] according to RINEX standards
     pub fn format<W: Write>(
@@ -70,7 +83,10 @@ impl Ephemeris {
             if i % 4 == 0 {
                 write!(w, "\n{}", padding)?;
             }
-            match self.get_orbit_f64(field) {
+            match self
+                .get_orbit_f64(field)
+                .or_else(|| orbit_alias(field).and_then(|alias| self.get_orbit_f64(alias)))
+            {
                 Some(value) => write!(w, "{}", formatter(value))?,
                 None => write!(w, "{}", BLANK)?,
             }

--- a/src/navigation/ephemeris/orbits.rs
+++ b/src/navigation/ephemeris/orbits.rs
@@ -232,6 +232,11 @@ impl OrbitItem {
 
                                 Ok(OrbitItem::GlonassHealth(flags))
                             },
+                            (NavMessageType::LNAV | NavMessageType::L1NV, Constellation::IRNSS) => {
+                                let flags = IrnssHealth::from_bits_retain(unsigned);
+
+                                Ok(OrbitItem::IrnssHealth(flags))
+                            },
                             (
                                 NavMessageType::LNAV | NavMessageType::D1 | NavMessageType::D2,
                                 Constellation::BeiDou,

--- a/src/navigation/ephemeris/orbits.rs
+++ b/src/navigation/ephemeris/orbits.rs
@@ -232,6 +232,15 @@ impl OrbitItem {
 
                                 Ok(OrbitItem::GlonassHealth(flags))
                             },
+                            (
+                                NavMessageType::L1OC | NavMessageType::L3OC,
+                                Constellation::Glonass,
+                            ) => {
+                                // CDMA messages (RINEX 4.02): every bit is kept
+                                let flags = GlonassHealth::from_bits_retain(unsigned);
+
+                                Ok(OrbitItem::GlonassHealth(flags))
+                            },
                             (NavMessageType::LNAV | NavMessageType::L1NV, Constellation::IRNSS) => {
                                 let flags = IrnssHealth::from_bits_retain(unsigned);
 

--- a/src/navigation/ephemeris/parsing.rs
+++ b/src/navigation/ephemeris/parsing.rs
@@ -550,4 +550,59 @@ mod test {
         assert_eq!(ephemeris.get_orbit_f64("t_tm"), Some(3.553500000000e+05));
         assert_eq!(ephemeris.get_orbit_f64("fitInt"), Some(4.0));
     }
+
+    #[test]
+    fn navic_lnav_v4() {
+        // RINEX 4.02 Table A32, in GPST (Table A30)
+        let content =
+            "I02 2020 09 15 02 05 36 6.225099787116e-04 1.773514668457e-11 0.000000000000e+00
+     1.690000000000e+02-5.793750000000e+02 4.834487090078e-09-4.281979621524e-01
+    -1.904368400574e-05 2.015684265643e-03-3.430992364883e-06 6.493289550781e+03
+     1.803360000000e+05 2.495944499969e-07-1.337499015334e+00 7.450580596924e-08
+     5.022043764738e-01 1.946250000000e+02-2.970970345572e+00-4.461614415577e-09
+    -9.578970431139e-10                    2.123000000000e+03
+     2.000000000000e+00 0.000000000000e+00-1.862645149231e-09
+     1.804920000000e+05";
+        let (epoch, sv, eph) =
+            Ephemeris::parse_v4(NavMessageType::LNAV, content.lines(), TimeScale::GPST).unwrap();
+        assert_eq!(sv, SV::from_str("I02").unwrap());
+        assert_eq!(epoch, Epoch::from_str("2020-09-15T02:05:36 GPST").unwrap());
+        assert_eq!(eph.clock_bias, 6.225099787116e-04);
+        assert_eq!(eph.get_orbit_f64("iodec"), Some(169.0));
+        assert_eq!(eph.get_orbit_f64("sqrta"), Some(6.493289550781e+03));
+        assert_eq!(eph.get_week(), Some(2123));
+        assert_eq!(eph.get_orbit_f64("accuracy"), Some(2.0));
+        assert_eq!(eph.get_orbit_f64("health"), Some(0.0));
+        assert_eq!(eph.get_orbit_f64("tgd"), Some(-1.862645149231e-09));
+        assert_eq!(eph.get_orbit_f64("t_tm"), Some(1.804920000000e+05));
+    }
+
+    #[test]
+    fn navic_l1nv_v4() {
+        // RINEX 4.02 Table A32
+        let content =
+            "I10 2023 06 24 00 05 00 1.527369022369e-07 1.364242052659e-12 0.000000000000e+00
+     0.000000000000e+00-2.593125000000e+02 7.028864208979e-09 2.300305834983e+00
+    -8.691102266312e-06 4.531537415460e-04-3.855675458908e-06 6.493495117188e+03
+     7.000000000000e+00 1.341104507446e-07 1.359342162629e-01-7.078051567078e-08
+     8.594830530333e-02 1.214375000000e+02-5.136403830694e-02-5.858815471753e-09
+    -4.846630453041e-10 0.000000000000e+00                    1.000000000000e+00
+     1.500000000000e+01 0.000000000000e+00                   -3.608874976635e-09
+                                           6.984919309616e-09 5.995389074087e-09
+     5.191380000000e+05";
+        let (epoch, sv, eph) =
+            Ephemeris::parse_v4(NavMessageType::L1NV, content.lines(), TimeScale::GPST).unwrap();
+        assert_eq!(sv, SV::from_str("I10").unwrap());
+        assert_eq!(epoch, Epoch::from_str("2023-06-24T00:05:00 GPST").unwrap());
+        assert_eq!(eph.get_orbit_f64("crs"), Some(-2.593125000000e+02));
+        assert_eq!(eph.get_orbit_f64("iodec"), Some(7.0));
+        assert_eq!(eph.get_orbit_f64("rsf"), Some(1.0));
+        assert_eq!(eph.get_orbit_f64("urai"), Some(15.0));
+        assert_eq!(eph.get_orbit_f64("health"), Some(0.0));
+        assert_eq!(eph.get_orbit_f64("tgdL1PL5"), None);
+        assert_eq!(eph.get_orbit_f64("tgdSL5"), Some(-3.608874976635e-09));
+        assert_eq!(eph.get_orbit_f64("iscL1PS"), Some(6.984919309616e-09));
+        assert_eq!(eph.get_orbit_f64("iscL1DS"), Some(5.995389074087e-09));
+        assert_eq!(eph.get_orbit_f64("t_tm"), Some(5.191380000000e+05));
+    }
 }

--- a/src/navigation/ephemeris/parsing.rs
+++ b/src/navigation/ephemeris/parsing.rs
@@ -2,7 +2,7 @@ use crate::{
     epoch::parse_in_timescale as parse_epoch_in_timescale,
     navigation::{
         ephemeris::orbits::{closest_nav_standards, OrbitItem},
-        Ephemeris, NavMessageType,
+        timescale, Ephemeris, NavMessageType,
     },
     parse_f64,
     prelude::{Constellation, Epoch, ParsingError, TimeScale, Version, SV},
@@ -130,10 +130,7 @@ impl Ephemeris {
             },
         };
 
-        let ts = sv
-            .constellation
-            .timescale()
-            .ok_or(ParsingError::NoTimescaleDefinition)?;
+        let ts = timescale(sv.constellation)?;
 
         let epoch = parse_epoch_in_timescale(date.trim(), ts)?;
 

--- a/src/navigation/ephemeris/parsing.rs
+++ b/src/navigation/ephemeris/parsing.rs
@@ -49,24 +49,24 @@ fn parse_orbits(
             false => &line[4..],
         };
 
-        let mut nb_missing = 4 - (line.len() / word_size);
-        // println!("LINE \"{}\" | NB MISSING {}", line, nb_missing); //DEBUG
+        // number of fields found on this line, blank or not
+        let mut nb_fields = 0;
 
         loop {
             if line.is_empty() {
-                key_index += nb_missing;
+                // fields omitted at the end of the line
+                key_index += 4_usize.saturating_sub(nb_fields);
                 break;
             }
 
             let (val_str, rem) = line.split_at(std::cmp::min(word_size, line.len()));
             let val_str = val_str.trim();
-            // println!("CONTENT \"{}\"", content); // DEBUG
+            nb_fields += 1;
 
             // handle omitted fields
             if val_str.is_empty() {
                 // omitted field
                 key_index += 1;
-                nb_missing = nb_missing.saturating_sub(1);
                 line = rem;
                 continue;
             }
@@ -224,8 +224,10 @@ impl Ephemeris {
 mod test {
     use crate::{
         navigation::{Ephemeris, NavMessageType},
-        prelude::{Constellation, Version},
+        prelude::{Constellation, Epoch, TimeScale, Version, SV},
     };
+
+    use std::str::FromStr;
 
     use super::parse_orbits;
 
@@ -510,5 +512,42 @@ mod test {
         assert_eq!(ephemeris.get_orbit_f64("velX"), None);
         assert_eq!(ephemeris.get_orbit_f64("satPosY"), Some(-0.216949155273E5));
         assert_eq!(ephemeris.get_orbit_f64("satPosZ"), Some(0.109021518555E5));
+    }
+
+    #[test]
+    fn blank_field_on_short_line() {
+        // A blank field followed by omitted trailing fields on the same
+        // line must not shift the fields of the following lines.
+        // GPS LNAV V4 line 5: idot, (blank l2 codes), week, omitted l2p flag
+        let content =
+            "     9.800000000000e+01-1.718750000000e+00 4.639836124941e-09 2.148941747752e+00
+    -1.881271600723e-07 3.355251392350e-04 8.245930075645e-06 5.153800453186e+03
+     3.600000000000e+05-1.676380634308e-08 5.171400020311e-01 1.490116119385e-08
+     9.601921900531e-01 2.187187500000e+02-1.736906885738e+00-8.044977962767e-09
+    -2.932264997750e-10                    2.044000000000e+03
+     4.000000000000e+00 6.300000000000e+01-8.847564458847e-09 8.660000000000e+02
+     3.553500000000e+05 4.000000000000e+00";
+        let orbits = parse_orbits(
+            Version::new(4, 0),
+            NavMessageType::LNAV,
+            Constellation::GPS,
+            content.lines(),
+        )
+        .unwrap();
+        let ephemeris = Ephemeris {
+            clock_bias: 0.0,
+            clock_drift: 0.0,
+            clock_drift_rate: 0.0,
+            orbits,
+        };
+        assert_eq!(ephemeris.get_orbit_f64("idot"), Some(-2.932264997750e-10));
+        assert_eq!(ephemeris.get_orbit_f64("l2Codes"), None);
+        assert_eq!(ephemeris.get_week(), Some(2044));
+        assert_eq!(ephemeris.get_orbit_f64("l2p"), None);
+        assert_eq!(ephemeris.get_orbit_f64("accuracy"), Some(4.0));
+        assert_eq!(ephemeris.get_orbit_f64("tgd"), Some(-8.847564458847e-09));
+        assert_eq!(ephemeris.get_orbit_f64("iodc"), Some(866.0));
+        assert_eq!(ephemeris.get_orbit_f64("t_tm"), Some(3.553500000000e+05));
+        assert_eq!(ephemeris.get_orbit_f64("fitInt"), Some(4.0));
     }
 }

--- a/src/navigation/ephemeris/parsing.rs
+++ b/src/navigation/ephemeris/parsing.rs
@@ -634,4 +634,28 @@ mod test {
             assert_eq!(eph.get_orbit_f64("t_tm"), Some(5.184000000000e+05));
         }
     }
+
+    #[test]
+    fn cnav_flags_field() {
+        // RINEX 4.02 Table A10: optional flags after wn_op
+        let content =
+            "G04 2019 03 14 03 30 00 1.330042141490e-04 7.226219622680e-12 0.000000000000e+00
+     2.001762390137e-03 6.914062500000e-01 4.625906973308e-09 1.887277537485e+00
+     1.024454832077e-08 3.348654136062e-04 8.376315236092e-06 5.153800325291e+03
+     2.412000000000e+05-4.656612873077e-09 5.171544951605e-01 2.328306436539e-08
+     9.601927657114e-01 2.174140625000e+02-1.737767543851e+00-8.034028170143e-09
+    -2.950122884460e-10-1.312310522376e-14-2.000000000000e+00 2.000000000000e+00
+     0.000000000000e+00 7.000000000000e+00-8.789356797934e-09 5.000000000000e+00
+    -5.820766091347e-10-6.606569513679e-09-1.178705133498e-08-1.178705133498e-08
+     3.558540000000e+05 2.044000000000e+03";
+        let (_, _, eph) =
+            Ephemeris::parse_v4(NavMessageType::CNAV, content.lines(), TimeScale::GPST).unwrap();
+        assert_eq!(eph.get_orbit_f64("wn_op"), Some(2044.0));
+        assert_eq!(eph.get_orbit_f64("flags"), None);
+
+        let content = format!("{} 3.000000000000e+00", content);
+        let (_, _, eph) =
+            Ephemeris::parse_v4(NavMessageType::CNAV, content.lines(), TimeScale::GPST).unwrap();
+        assert_eq!(eph.get_orbit_f64("flags"), Some(3.0));
+    }
 }

--- a/src/navigation/ephemeris/parsing.rs
+++ b/src/navigation/ephemeris/parsing.rs
@@ -605,4 +605,33 @@ mod test {
         assert_eq!(eph.get_orbit_f64("iscL1DS"), Some(5.995389074087e-09));
         assert_eq!(eph.get_orbit_f64("t_tm"), Some(5.191380000000e+05));
     }
+
+    #[test]
+    fn glonass_l1oc_v4() {
+        // RINEX 4.02 Table A18
+        let content =
+            "R26 2024 02 03 00 15 00-1.605716170161e-05 1.652011860642e-12-2.081668171172e-17
+     1.812154053020e+04-2.071979139000e+00 5.729816621169e-10 1.000000000000e+00
+    -2.325615360260e+03 1.285475494340e+00-1.047737896442e-09 1.000000000000e+00
+     1.781341854668e+04 2.280306640081e+00-9.458744898438e-10 0.000000000000e+00
+     2.000000000000e+00 1.000000000000e+01 7.500000000000e-01 7.500000000000e-01
+     0.000000000000e+00 0.000000000000e+00 0.000000000000e+00 0.000000000000e+00
+     0.000000000000e+00 0.000000000000e+00 0.000000000000e+00 0.000000000000e+00
+     0.000000000000e+00 0.000000000000e+00 0.000000000000e+00 0.000000000000e+00
+     1.500000000000e+01 5.000000000000e+00                    5.184000000000e+05";
+        for msgtype in [NavMessageType::L1OC, NavMessageType::L3OC] {
+            let (epoch, sv, eph) =
+                Ephemeris::parse_v4(msgtype, content.lines(), TimeScale::UTC).unwrap();
+            assert_eq!(sv, SV::from_str("R26").unwrap());
+            assert_eq!(epoch, Epoch::from_str("2024-02-03T00:15:00 UTC").unwrap());
+            assert_eq!(eph.get_orbit_f64("satPosX"), Some(1.812154053020e+04));
+            assert_eq!(eph.get_orbit_f64("health"), Some(1.0));
+            assert_eq!(eph.get_orbit_f64("dataValidity"), Some(1.0));
+            assert_eq!(eph.get_orbit_f64("satType"), Some(2.0));
+            assert_eq!(eph.get_orbit_f64("sourceFlags"), Some(10.0));
+            assert_eq!(eph.get_orbit_f64("uraiOrb"), Some(15.0));
+            assert_eq!(eph.get_orbit_f64("uraiClk"), Some(5.0));
+            assert_eq!(eph.get_orbit_f64("t_tm"), Some(5.184000000000e+05));
+        }
+    }
 }

--- a/src/navigation/formatting.rs
+++ b/src/navigation/formatting.rs
@@ -151,18 +151,31 @@ pub(crate) fn format_epoch_v4_fields(epoch: Epoch) -> String {
 /// The ephemeris epoch line follows, the other records write their
 /// own epoch line along with their data.
 fn format_epoch_v4<W: Write>(w: &mut BufWriter<W>, k: &NavKey) -> std::io::Result<()> {
+    // records naming the constellation only carry PRN 0
+    let sv = if k.sv.prn == 0 {
+        format!("{:x}  ", k.sv.constellation)
+    } else {
+        format!("{:x}", k.sv)
+    };
+
+    // message type, and RINEX 4.02 subtype when defined
+    let msgtype = match k.subtype {
+        Some(subtype) => format!("{} {}", k.msgtype, subtype),
+        None => k.msgtype.to_string(),
+    };
+
     match k.frmtype {
         NavFrameType::Ephemeris => {
             write!(
                 w,
-                "> EPH {:x} {}\n{:x} {}",
-                k.sv,
-                k.msgtype,
-                k.sv,
+                "> EPH {} {}\n{} {}",
+                sv,
+                msgtype,
+                sv,
                 format_epoch_v4_fields(k.epoch)
             )
         },
-        frmtype => writeln!(w, "> {} {:x} {}", frmtype, k.sv, k.msgtype),
+        frmtype => writeln!(w, "> {} {} {}", frmtype, sv, msgtype),
     }
 }
 
@@ -279,6 +292,7 @@ mod test {
             sv: SV::from_str("E01").unwrap(),
             frmtype: NavFrameType::from_str("EOP").unwrap(),
             msgtype: NavMessageType::from_str("LNAV").unwrap(),
+            subtype: None,
         };
 
         format_epoch_v2v3(&mut writer, &key, true, &gal).unwrap();
@@ -300,6 +314,7 @@ mod test {
             sv: SV::from_str("G01").unwrap(),
             frmtype: NavFrameType::from_str("EPH").unwrap(),
             msgtype: NavMessageType::from_str("LNAV").unwrap(),
+            subtype: None,
         };
 
         format_epoch_v4(&mut writer, &key).unwrap();
@@ -325,6 +340,7 @@ G01 2023 03 12 00 00 00"
             sv: SV::from_str("G12").unwrap(),
             frmtype: NavFrameType::from_str("ION").unwrap(),
             msgtype: NavMessageType::from_str("LNAV").unwrap(),
+            subtype: None,
         };
 
         format_epoch_v4(&mut writer, &key).unwrap();
@@ -347,6 +363,7 @@ G01 2023 03 12 00 00 00"
             sv: SV::from_str("C21").unwrap(),
             frmtype: NavFrameType::from_str("STO").unwrap(),
             msgtype: NavMessageType::from_str("CNVX").unwrap(),
+            subtype: None,
         };
 
         format_epoch_v4(&mut writer, &key).unwrap();
@@ -368,6 +385,7 @@ G01 2023 03 12 00 00 00"
             sv: SV::from_str("G27").unwrap(),
             frmtype: NavFrameType::from_str("EOP").unwrap(),
             msgtype: NavMessageType::from_str("CNVX").unwrap(),
+            subtype: None,
         };
 
         format_epoch_v4(&mut writer, &key).unwrap();

--- a/src/navigation/formatting.rs
+++ b/src/navigation/formatting.rs
@@ -219,7 +219,9 @@ fn v4_message_type(k: &NavKey, eph: &Ephemeris) -> NavMessageType {
 ///   (CNAV, CNV1 to CNV3) and the STO, EOP and ION records have no
 ///   representation there and are skipped. A RINEX 2 file names a single
 ///   constellation: the satellites of the other constellations are
-///   skipped too.
+///   skipped too. When the record is not empty and none of its frames can
+///   be written, [FormattingError::NoRepresentableFrame] is returned
+///   before anything is written.
 pub fn format<W: Write>(
     writer: &mut BufWriter<W>,
     rec: &Record,
@@ -252,6 +254,10 @@ pub fn format<W: Write>(
             None => true,
         }
     };
+
+    if !v4 && !rec.is_empty() && !rec.iter().any(|(k, frame)| representable(k, frame)) {
+        return Err(FormattingError::NoRepresentableFrame);
+    }
 
     // the record is sorted by key: chronological order, then vehicle,
     // then message type. Every entry is written, including messages of

--- a/src/navigation/formatting.rs
+++ b/src/navigation/formatting.rs
@@ -3,7 +3,7 @@ use std::io::{BufWriter, Write};
 use crate::{
     epoch::epoch_decompose as epoch_decomposition,
     error::FormattingError,
-    navigation::{NavFrame, NavFrameType, NavKey, Record},
+    navigation::{Ephemeris, NavFrame, NavFrameType, NavKey, NavMessageType, Record},
     prelude::{Constellation, Epoch, Header},
 };
 
@@ -179,6 +179,47 @@ fn format_epoch_v4<W: Write>(w: &mut BufWriter<W>, k: &NavKey) -> std::io::Resul
     }
 }
 
+/// RINEX 4 message type of an ephemeris parsed from a RINEX 2 or 3 file,
+/// where every message is filed as LNAV: the legacy message of the
+/// constellation. Galileo tells INAV from FNAV by the data source
+/// (Table A13), BeiDou tells D2 (GEO) from D1 by the PRN range (BDS ICD).
+fn v4_message_type(k: &NavKey, eph: &Ephemeris) -> NavMessageType {
+    if k.msgtype != NavMessageType::LNAV {
+        return k.msgtype;
+    }
+    match k.sv.constellation {
+        Constellation::Glonass => NavMessageType::FDMA,
+        Constellation::Galileo => {
+            let data_source = eph.get_orbit_f64("source").unwrap_or(0.0) as u32;
+            if data_source & 0x02 != 0 {
+                NavMessageType::FNAV
+            } else {
+                NavMessageType::INAV
+            }
+        },
+        Constellation::BeiDou => {
+            if k.sv.prn <= 5 || k.sv.prn >= 59 {
+                NavMessageType::D2
+            } else {
+                NavMessageType::D1
+            }
+        },
+        c if c.is_sbas() => NavMessageType::SBAS,
+        _ => NavMessageType::LNAV,
+    }
+}
+
+/// Formats the navigation [Record] in the revision of the [Header].
+///
+/// The record is written as parsed when the revisions match. Otherwise:
+/// - written as RINEX 4, ephemerides parsed from RINEX 2 or 3 get the
+///   message type of their constellation (see [v4_message_type]);
+/// - written as RINEX 2 or 3, only the ephemerides of the legacy messages
+///   are kept, laid out with the RINEX 3 definitions; the modern messages
+///   (CNAV, CNV1 to CNV3) and the STO, EOP and ION records have no
+///   representation there and are skipped. A RINEX 2 file names a single
+///   constellation: the satellites of the other constellations are
+///   skipped too.
 pub fn format<W: Write>(
     writer: &mut BufWriter<W>,
     rec: &Record,
@@ -193,25 +234,59 @@ pub fn format<W: Write>(
         .constellation
         .ok_or(FormattingError::UndefinedConstellation)?;
 
+    // RINEX 2: single constellation file
+    let constellation = if v2 && file_constell != Constellation::Mixed {
+        Some(file_constell)
+    } else {
+        None
+    };
+
+    // frames with a representation prior RINEX 4
+    let representable = |k: &NavKey, frame: &NavFrame| {
+        if frame.as_ephemeris().is_none() || !k.msgtype.is_legacy(k.sv.constellation) {
+            return false;
+        }
+        match constellation {
+            Some(constellation) if constellation.is_sbas() => k.sv.constellation.is_sbas(),
+            Some(constellation) => k.sv.constellation == constellation,
+            None => true,
+        }
+    };
+
     // the record is sorted by key: chronological order, then vehicle,
     // then message type. Every entry is written, including messages of
     // different types sharing an epoch and vehicle.
     for (k, v) in rec.iter() {
         if v4 {
-            format_epoch_v4(writer, k)?;
-        } else {
             match v {
-                NavFrame::EPH(_) => format_epoch_v2v3(writer, k, v2, &file_constell)?,
-                // no record representation before RINEX 4
-                _ => continue,
+                NavFrame::EPH(eph) => {
+                    let key = NavKey {
+                        msgtype: v4_message_type(k, eph),
+                        ..*k
+                    };
+                    format_epoch_v4(writer, &key)?;
+                    eph.format(writer, key.sv, version, key.msgtype)?;
+                },
+                NavFrame::STO(sto) => {
+                    format_epoch_v4(writer, k)?;
+                    sto.format_v4(writer)?;
+                },
+                NavFrame::EOP(eop) => {
+                    format_epoch_v4(writer, k)?;
+                    eop.format_v4(writer, k.epoch)?;
+                },
+                NavFrame::ION(model) => {
+                    format_epoch_v4(writer, k)?;
+                    model.format_v4(writer, k.epoch)?;
+                },
             }
-        }
-
-        match v {
-            NavFrame::EPH(eph) => eph.format(writer, k.sv, version, k.msgtype)?,
-            NavFrame::STO(sto) => sto.format_v4(writer)?,
-            NavFrame::EOP(eop) => eop.format_v4(writer, k.epoch)?,
-            NavFrame::ION(model) => model.format_v4(writer, k.epoch)?,
+        } else if let Some(eph) = v.as_ephemeris() {
+            if !representable(k, v) {
+                continue;
+            }
+            format_epoch_v2v3(writer, k, v2, &file_constell)?;
+            // RINEX 2 and 3 definitions are filed as LNAV
+            eph.format(writer, k.sv, version, NavMessageType::LNAV)?;
         }
     }
 

--- a/src/navigation/ionosphere/glonass.rs
+++ b/src/navigation/ionosphere/glonass.rs
@@ -1,0 +1,86 @@
+//! GLONASS CDMA ionosphere model (RINEX 4.02)
+use crate::{
+    epoch::parse_in_timescale as parse_epoch_in_timescale,
+    navigation::ionosphere::parse_e19_fields,
+    prelude::{Epoch, ParsingError, TimeScale},
+};
+
+#[cfg(feature = "serde")]
+use serde::Serialize;
+
+/// GLONASS CDMA ionosphere model, from the LXOC ION message (RINEX 4.02 Table A40)
+#[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+pub struct GloCdmaModel {
+    /// c_A coefficient
+    pub c_a: f64,
+    /// c_F10.7 coefficient
+    pub c_f107: f64,
+    /// c_Ap coefficient
+    pub c_ap: f64,
+}
+
+impl GloCdmaModel {
+    /// Formats the RINEX 4.02 GLONASS CDMA ION record (Table A40).
+    pub(crate) fn format_v4<W: std::io::Write>(
+        &self,
+        w: &mut std::io::BufWriter<W>,
+        epoch: Epoch,
+    ) -> Result<(), crate::error::FormattingError> {
+        use crate::navigation::formatting::{format_epoch_v4_fields, NavFormatter};
+        use std::io::Write;
+
+        writeln!(
+            w,
+            "    {}{}{}{}",
+            format_epoch_v4_fields(epoch),
+            NavFormatter::new(self.c_a),
+            NavFormatter::new(self.c_f107),
+            NavFormatter::new(self.c_ap),
+        )?;
+
+        Ok(())
+    }
+
+    /// Parses [GloCdmaModel] from lines Iter
+    pub(crate) fn parse(
+        mut lines: std::str::Lines<'_>,
+        ts: TimeScale,
+    ) -> Result<(Epoch, Self), ParsingError> {
+        let line = lines.next().ok_or(ParsingError::EmptyEpoch)?;
+        let (epoch, rem) = line.split_at(23);
+        let epoch = parse_epoch_in_timescale(epoch.trim(), ts)?;
+        let c = parse_e19_fields(rem, 0, 3).ok_or(ParsingError::GlonassIonosphereData)?;
+        Ok((
+            epoch,
+            Self {
+                c_a: c[0],
+                c_f107: c[1],
+                c_ap: c[2],
+            },
+        ))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn glonass_cdma() {
+        // RINEX 4.02 Table A41, without the record header
+        let content =
+            "    2024 02 03 00 01 09 1.000000000000e+00 1.410000000000e+02 5.000000000000e+00";
+        let (epoch, model) = GloCdmaModel::parse(content.lines(), TimeScale::UTC).unwrap();
+        assert_eq!(epoch, Epoch::from_str("2024-02-03T00:01:09 UTC").unwrap());
+        assert_eq!(
+            model,
+            GloCdmaModel {
+                c_a: 1.0,
+                c_f107: 141.0,
+                c_ap: 5.0,
+            }
+        );
+    }
+}

--- a/src/navigation/ionosphere/mod.rs
+++ b/src/navigation/ionosphere/mod.rs
@@ -2,7 +2,9 @@ use crate::parse_f64;
 use crate::prelude::ParsingError;
 
 mod bdgim;
+mod glonass;
 mod klobuchar;
+mod navic;
 mod nequick_g;
 
 #[cfg(feature = "ublox")]
@@ -10,8 +12,22 @@ mod nequick_g;
 pub mod ublox;
 
 pub use bdgim::BdModel;
+pub use glonass::GloCdmaModel;
 pub use klobuchar::{KbModel, KbRegionCode};
+pub use navic::{NavicKbModel, NavicNeqnModel, NavicNeqnRegion};
 pub use nequick_g::{NgModel, NgRegionFlags};
+
+/// Parses `n` consecutive E19.12 fields starting at column `offset`.
+/// Returns None if a field is missing or invalid.
+pub(crate) fn parse_e19_fields(line: &str, offset: usize, n: usize) -> Option<Vec<f64>> {
+    let line = line.get(offset..)?;
+    let mut values = Vec::with_capacity(n);
+    for i in 0..n {
+        let field = line.get(i * 19..(i + 1) * 19)?;
+        values.push(parse_f64(field.trim()).ok()?);
+    }
+    Some(values)
+}
 
 /// [IonosphereModel] that may be described in modern NAV V4 RINEx
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
@@ -25,6 +41,15 @@ pub enum IonosphereModel {
 
     /// BDGIM [BdModel] streamed by BDS
     Bdgim(BdModel),
+
+    /// NavIC Klobuchar model (RINEX 4.02 L1NV KLOB message)
+    NavicKlobuchar(NavicKbModel),
+
+    /// NavIC NeQuick-N model (RINEX 4.02 L1NV NEQN message)
+    NavicNequick(NavicNeqnModel),
+
+    /// GLONASS CDMA model (RINEX 4.02 LXOC message)
+    GlonassCdma(GloCdmaModel),
 }
 
 impl IonosphereModel {
@@ -38,6 +63,9 @@ impl IonosphereModel {
             Self::Klobuchar(model) => model.format_v4(w, epoch),
             Self::NequickG(model) => model.format_v4(w, epoch),
             Self::Bdgim(model) => model.format_v4(w, epoch),
+            Self::NavicKlobuchar(model) => model.format_v4(w, epoch),
+            Self::NavicNequick(model) => model.format_v4(w, epoch),
+            Self::GlonassCdma(model) => model.format_v4(w, epoch),
         }
     }
 }
@@ -198,6 +226,30 @@ impl IonosphereModel {
     pub fn as_bdgim(&self) -> Option<&BdModel> {
         match self {
             Self::Bdgim(model) => Some(model),
+            _ => None,
+        }
+    }
+
+    /// Returns reference to NavIC Klobuchar [NavicKbModel]
+    pub fn as_navic_klobuchar(&self) -> Option<&NavicKbModel> {
+        match self {
+            Self::NavicKlobuchar(model) => Some(model),
+            _ => None,
+        }
+    }
+
+    /// Returns reference to NavIC NeQuick-N [NavicNeqnModel]
+    pub fn as_navic_nequick(&self) -> Option<&NavicNeqnModel> {
+        match self {
+            Self::NavicNequick(model) => Some(model),
+            _ => None,
+        }
+    }
+
+    /// Returns reference to GLONASS CDMA [GloCdmaModel]
+    pub fn as_glonass_cdma(&self) -> Option<&GloCdmaModel> {
+        match self {
+            Self::GlonassCdma(model) => Some(model),
             _ => None,
         }
     }

--- a/src/navigation/ionosphere/navic.rs
+++ b/src/navigation/ionosphere/navic.rs
@@ -1,0 +1,287 @@
+//! NavIC L1NV ionosphere models (RINEX 4.02)
+use crate::{
+    epoch::parse_in_timescale as parse_epoch_in_timescale,
+    navigation::ionosphere::parse_e19_fields,
+    prelude::{Epoch, ParsingError, TimeScale},
+};
+
+#[cfg(feature = "serde")]
+use serde::Serialize;
+
+/// NavIC Klobuchar model, from the L1NV ION KLOB message (RINEX 4.02 Table A38)
+#[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+pub struct NavicKbModel {
+    /// Issue of data, Klobuchar
+    pub iodk: f64,
+    /// Alpha coefficients
+    /// ((sec), (sec.semi-circle⁻¹), (sec.semi-circle⁻²), (sec.semi-circle⁻³))
+    pub alpha: (f64, f64, f64, f64),
+    /// Beta coefficients
+    /// ((sec), (sec.semi-circle⁻¹), (sec.semi-circle⁻²), (sec.semi-circle⁻³))
+    pub beta: (f64, f64, f64, f64),
+    /// Region of validity: (min, max) longitude in degrees
+    pub longitude_deg: (f64, f64),
+    /// Region of validity: (min, max) latitude in degrees
+    pub latitude_deg: (f64, f64),
+}
+
+impl NavicKbModel {
+    /// Formats the RINEX 4.02 NavIC Klobuchar ION record (Table A38).
+    pub(crate) fn format_v4<W: std::io::Write>(
+        &self,
+        w: &mut std::io::BufWriter<W>,
+        epoch: Epoch,
+    ) -> Result<(), crate::error::FormattingError> {
+        use crate::navigation::formatting::{format_epoch_v4_fields, NavFormatter};
+        use std::io::Write;
+
+        writeln!(
+            w,
+            "    {}{}",
+            format_epoch_v4_fields(epoch),
+            NavFormatter::new(self.iodk)
+        )?;
+
+        writeln!(
+            w,
+            "    {}{}{}{}",
+            NavFormatter::new(self.alpha.0),
+            NavFormatter::new(self.alpha.1),
+            NavFormatter::new(self.alpha.2),
+            NavFormatter::new(self.alpha.3),
+        )?;
+
+        writeln!(
+            w,
+            "    {}{}{}{}",
+            NavFormatter::new(self.beta.0),
+            NavFormatter::new(self.beta.1),
+            NavFormatter::new(self.beta.2),
+            NavFormatter::new(self.beta.3),
+        )?;
+
+        writeln!(
+            w,
+            "    {}{}{}{}",
+            NavFormatter::new(self.longitude_deg.0),
+            NavFormatter::new(self.longitude_deg.1),
+            NavFormatter::new(self.latitude_deg.0),
+            NavFormatter::new(self.latitude_deg.1),
+        )?;
+
+        Ok(())
+    }
+
+    /// Parses [NavicKbModel] from lines Iter
+    pub(crate) fn parse(
+        mut lines: std::str::Lines<'_>,
+        ts: TimeScale,
+    ) -> Result<(Epoch, Self), ParsingError> {
+        let line = lines.next().ok_or(ParsingError::EmptyEpoch)?;
+        let (epoch, rem) = line.split_at(23);
+        let epoch = parse_epoch_in_timescale(epoch.trim(), ts)?;
+        let iodk = parse_e19_fields(rem, 0, 1).ok_or(ParsingError::NavicIonosphereData)?[0];
+
+        let line = lines.next().ok_or(ParsingError::EmptyEpoch)?;
+        let alpha = parse_e19_fields(line, 4, 4).ok_or(ParsingError::NavicIonosphereData)?;
+
+        let line = lines.next().ok_or(ParsingError::EmptyEpoch)?;
+        let beta = parse_e19_fields(line, 4, 4).ok_or(ParsingError::NavicIonosphereData)?;
+
+        let line = lines.next().ok_or(ParsingError::EmptyEpoch)?;
+        let region = parse_e19_fields(line, 4, 4).ok_or(ParsingError::NavicIonosphereData)?;
+
+        Ok((
+            epoch,
+            Self {
+                iodk,
+                alpha: (alpha[0], alpha[1], alpha[2], alpha[3]),
+                beta: (beta[0], beta[1], beta[2], beta[3]),
+                longitude_deg: (region[0], region[1]),
+                latitude_deg: (region[2], region[3]),
+            },
+        ))
+    }
+}
+
+/// One region of the NavIC NeQuick-N model
+#[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+pub struct NavicNeqnRegion {
+    /// a_i coefficients (sfu, (sfu.deg⁻¹), (sfu.deg⁻²))
+    pub a: (f64, f64, f64),
+    /// Ionosphere disturbance flag
+    pub idf: f64,
+    /// Region of validity: (min, max) longitude in degrees
+    pub longitude_deg: (f64, f64),
+    /// Region of validity: (min, max) modified dip latitude in degrees
+    pub modip_deg: (f64, f64),
+}
+
+/// NavIC NeQuick-N model, from the L1NV ION NEQN message (RINEX 4.02 Table A39)
+#[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+pub struct NavicNeqnModel {
+    /// Issue of data, NeQuick-N
+    pub iodn: f64,
+    /// Three regional coefficient sets
+    pub regions: [NavicNeqnRegion; 3],
+}
+
+impl NavicNeqnModel {
+    /// Formats the RINEX 4.02 NavIC NeQuick-N ION record (Table A39).
+    pub(crate) fn format_v4<W: std::io::Write>(
+        &self,
+        w: &mut std::io::BufWriter<W>,
+        epoch: Epoch,
+    ) -> Result<(), crate::error::FormattingError> {
+        use crate::navigation::formatting::{format_epoch_v4_fields, NavFormatter};
+        use std::io::Write;
+
+        writeln!(
+            w,
+            "    {}{}",
+            format_epoch_v4_fields(epoch),
+            NavFormatter::new(self.iodn)
+        )?;
+
+        for region in self.regions.iter() {
+            writeln!(
+                w,
+                "    {}{}{}{}",
+                NavFormatter::new(region.a.0),
+                NavFormatter::new(region.a.1),
+                NavFormatter::new(region.a.2),
+                NavFormatter::new(region.idf),
+            )?;
+
+            writeln!(
+                w,
+                "    {}{}{}{}",
+                NavFormatter::new(region.longitude_deg.0),
+                NavFormatter::new(region.longitude_deg.1),
+                NavFormatter::new(region.modip_deg.0),
+                NavFormatter::new(region.modip_deg.1),
+            )?;
+        }
+
+        Ok(())
+    }
+
+    /// Parses [NavicNeqnModel] from lines Iter
+    pub(crate) fn parse(
+        mut lines: std::str::Lines<'_>,
+        ts: TimeScale,
+    ) -> Result<(Epoch, Self), ParsingError> {
+        let line = lines.next().ok_or(ParsingError::EmptyEpoch)?;
+        let (epoch, rem) = line.split_at(23);
+        let epoch = parse_epoch_in_timescale(epoch.trim(), ts)?;
+        let iodn = parse_e19_fields(rem, 0, 1).ok_or(ParsingError::NavicIonosphereData)?[0];
+
+        let mut regions = [NavicNeqnRegion::default(); 3];
+
+        for region in regions.iter_mut() {
+            let line = lines.next().ok_or(ParsingError::EmptyEpoch)?;
+            let a = parse_e19_fields(line, 4, 4).ok_or(ParsingError::NavicIonosphereData)?;
+
+            let line = lines.next().ok_or(ParsingError::EmptyEpoch)?;
+            let bounds = parse_e19_fields(line, 4, 4).ok_or(ParsingError::NavicIonosphereData)?;
+
+            *region = NavicNeqnRegion {
+                a: (a[0], a[1], a[2]),
+                idf: a[3],
+                longitude_deg: (bounds[0], bounds[1]),
+                modip_deg: (bounds[2], bounds[3]),
+            };
+        }
+
+        Ok((epoch, Self { iodn, regions }))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn navic_klobuchar() {
+        // RINEX 4.02 Table A41, without the record header
+        let content = "    2023 06 24 00 07 30 1.000000000000e+00
+     5.867332220078e-08 2.533197402954e-07-1.430511474609e-06-7.510185241699e-06
+     1.495040000000e+05-5.406720000000e+05 2.883584000000e+06 8.323072000000e+06
+     5.000000000000e+01 1.100000000000e+02 0.000000000000e+00 5.000000000000e+01";
+        let (epoch, model) = NavicKbModel::parse(content.lines(), TimeScale::GPST).unwrap();
+        assert_eq!(epoch, Epoch::from_str("2023-06-24T00:07:30 GPST").unwrap());
+        assert_eq!(
+            model,
+            NavicKbModel {
+                iodk: 1.0,
+                alpha: (
+                    5.867332220078e-08,
+                    2.533197402954e-07,
+                    -1.430511474609e-06,
+                    -7.510185241699e-06
+                ),
+                beta: (
+                    1.495040000000e+05,
+                    -5.406720000000e+05,
+                    2.883584000000e+06,
+                    8.323072000000e+06
+                ),
+                longitude_deg: (50.0, 110.0),
+                latitude_deg: (0.0, 50.0),
+            }
+        );
+    }
+
+    #[test]
+    fn navic_nequick() {
+        // RINEX 4.02 Table A41, without the record header
+        let content = "    2023 06 24 00 17 24 0.000000000000e+00
+     1.982500000000e+02 0.000000000000e+00 0.000000000000e+00 1.000000000000e+00
+     3.000000000000e+01 1.300000000000e+02-3.000000000000e+01-1.000000000000e+01
+     2.085000000000e+02-3.085937500000e-01-3.417968750000e-03 1.000000000000e+00
+     3.000000000000e+01 1.300000000000e+02-5.000000000000e+00 3.000000000000e+01
+     1.982500000000e+02 0.000000000000e+00 0.000000000000e+00 1.000000000000e+00
+     3.000000000000e+01 1.300000000000e+02 3.500000000000e+01 5.000000000000e+01";
+        let (epoch, model) = NavicNeqnModel::parse(content.lines(), TimeScale::GPST).unwrap();
+        assert_eq!(epoch, Epoch::from_str("2023-06-24T00:17:24 GPST").unwrap());
+        assert_eq!(model.iodn, 0.0);
+        assert_eq!(
+            model.regions[0],
+            NavicNeqnRegion {
+                a: (198.25, 0.0, 0.0),
+                idf: 1.0,
+                longitude_deg: (30.0, 130.0),
+                modip_deg: (-30.0, -10.0),
+            }
+        );
+        assert_eq!(
+            model.regions[1],
+            NavicNeqnRegion {
+                a: (208.5, -3.085937500000e-01, -3.417968750000e-03),
+                idf: 1.0,
+                longitude_deg: (30.0, 130.0),
+                modip_deg: (-5.0, 30.0),
+            }
+        );
+        assert_eq!(
+            model.regions[2],
+            NavicNeqnRegion {
+                a: (198.25, 0.0, 0.0),
+                idf: 1.0,
+                longitude_deg: (30.0, 130.0),
+                modip_deg: (35.0, 50.0),
+            }
+        );
+    }
+
+    #[test]
+    fn navic_nequick_truncated() {
+        let content = "    2023 06 24 00 17 24 0.000000000000e+00
+     1.982500000000e+02 0.000000000000e+00 0.000000000000e+00 1.000000000000e+00";
+        assert!(NavicNeqnModel::parse(content.lines(), TimeScale::GPST).is_err());
+    }
+}

--- a/src/navigation/message.rs
+++ b/src/navigation/message.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::prelude::ParsingError;
+use crate::prelude::{Constellation, ParsingError};
 
 #[cfg(doc)]
 use crate::bibliography::Bibliography;
@@ -92,6 +92,24 @@ impl std::str::FromStr for NavMessageType {
     }
 }
 
+impl NavMessageType {
+    /// Returns true if this message, broadcast by `constellation`, has a
+    /// representation in RINEX 2 and 3: the legacy message of each
+    /// constellation, which those revisions do not name. The modern
+    /// messages (CNAV, CNV1 to CNV3, L1NV, L1OC, L3OC) only exist in
+    /// RINEX 4, as do the STO, EOP and ION message types.
+    pub fn is_legacy(self, constellation: Constellation) -> bool {
+        match self {
+            Self::LNAV => true,
+            Self::FDMA => constellation == Constellation::Glonass,
+            Self::INAV | Self::FNAV => constellation == Constellation::Galileo,
+            Self::D1 | Self::D2 => constellation == Constellation::BeiDou,
+            Self::SBAS => constellation.is_sbas(),
+            _ => false,
+        }
+    }
+}
+
 impl std::fmt::Display for NavMessageType {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
@@ -178,6 +196,43 @@ mod test {
             assert_eq!(msgtype.to_string(), code);
         }
         assert!(NavMessageType::from_str("LEG").is_err());
+    }
+
+    #[test]
+    fn legacy_messages() {
+        use crate::prelude::Constellation;
+
+        for (msgtype, constellation, legacy) in [
+            (NavMessageType::LNAV, Constellation::GPS, true),
+            (NavMessageType::LNAV, Constellation::IRNSS, true),
+            (NavMessageType::FDMA, Constellation::Glonass, true),
+            (NavMessageType::FDMA, Constellation::GPS, false),
+            (NavMessageType::INAV, Constellation::Galileo, true),
+            (NavMessageType::FNAV, Constellation::Galileo, true),
+            (NavMessageType::INAV, Constellation::Glonass, false),
+            (NavMessageType::D1, Constellation::BeiDou, true),
+            (NavMessageType::D2, Constellation::BeiDou, true),
+            (NavMessageType::D2, Constellation::GPS, false),
+            (NavMessageType::SBAS, Constellation::EGNOS, true),
+            (NavMessageType::SBAS, Constellation::GPS, false),
+            (NavMessageType::CNAV, Constellation::GPS, false),
+            (NavMessageType::CNV2, Constellation::QZSS, false),
+            (NavMessageType::CNV3, Constellation::BeiDou, false),
+            (NavMessageType::IFNV, Constellation::Galileo, false),
+            (NavMessageType::CNVX, Constellation::GPS, false),
+            (NavMessageType::L1NV, Constellation::IRNSS, false),
+            (NavMessageType::L1OC, Constellation::Glonass, false),
+            (NavMessageType::L3OC, Constellation::Glonass, false),
+            (NavMessageType::LXOC, Constellation::Glonass, false),
+        ] {
+            assert_eq!(
+                msgtype.is_legacy(constellation),
+                legacy,
+                "{} {:?}",
+                msgtype,
+                constellation
+            );
+        }
     }
 
     #[test]

--- a/src/navigation/message.rs
+++ b/src/navigation/message.rs
@@ -53,6 +53,14 @@ pub enum NavMessageType {
 
     /// CNVX special marker
     CNVX,
+    /// NavIC L1 NAV message (RINEX 4.02)
+    L1NV,
+    /// Glonass L1OC CDMA message (RINEX 4.02)
+    L1OC,
+    /// Glonass L3OC CDMA message (RINEX 4.02)
+    L3OC,
+    /// LXOC: Glonass CDMA STO, EOP and ION messages (RINEX 4.02)
+    LXOC,
 }
 
 impl std::str::FromStr for NavMessageType {
@@ -75,6 +83,10 @@ impl std::str::FromStr for NavMessageType {
             "CNV2" => Ok(Self::CNV2),
             "CNV3" => Ok(Self::CNV3),
             "CNVX" => Ok(Self::CNVX),
+            "L1NV" => Ok(Self::L1NV),
+            "L1OC" => Ok(Self::L1OC),
+            "L3OC" => Ok(Self::L3OC),
+            "LXOC" => Ok(Self::LXOC),
             _ => Err(ParsingError::NavMsgType),
         }
     }
@@ -97,6 +109,89 @@ impl std::fmt::Display for NavMessageType {
             Self::CNV2 => write!(f, "CNV2"),
             Self::CNV3 => write!(f, "CNV3"),
             Self::CNVX => write!(f, "CNVX"),
+            Self::L1NV => write!(f, "L1NV"),
+            Self::L1OC => write!(f, "L1OC"),
+            Self::L3OC => write!(f, "L3OC"),
+            Self::LXOC => write!(f, "LXOC"),
         }
+    }
+}
+
+/// Navigation message subtype, introduced by RINEX 4.02 as an optional
+/// fourth field of the navigation record header line (section 5.4.1).
+/// Subtypes are only defined for a few ION messages (Table 25) and
+/// distinguish otherwise identical records.
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum NavMessageSubtype {
+    /// QZSS CNVX ION: wide area coefficients
+    WIDE,
+    /// QZSS CNVX ION: Japan area coefficients
+    JAPN,
+    /// NavIC L1NV ION: Klobuchar model
+    KLOB,
+    /// NavIC L1NV ION: NeQuick-N model
+    NEQN,
+}
+
+impl std::str::FromStr for NavMessageSubtype {
+    type Err = ParsingError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_uppercase().as_str() {
+            "WIDE" => Ok(Self::WIDE),
+            "JAPN" => Ok(Self::JAPN),
+            "KLOB" => Ok(Self::KLOB),
+            "NEQN" => Ok(Self::NEQN),
+            _ => Err(ParsingError::NavMsgSubtype),
+        }
+    }
+}
+
+impl std::fmt::Display for NavMessageSubtype {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::WIDE => write!(f, "WIDE"),
+            Self::JAPN => write!(f, "JAPN"),
+            Self::KLOB => write!(f, "KLOB"),
+            Self::NEQN => write!(f, "NEQN"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn message_type() {
+        for (code, msgtype) in [
+            ("LNAV", NavMessageType::LNAV),
+            ("FDMA", NavMessageType::FDMA),
+            ("CNVX", NavMessageType::CNVX),
+            ("L1NV", NavMessageType::L1NV),
+            ("L1OC", NavMessageType::L1OC),
+            ("L3OC", NavMessageType::L3OC),
+            ("LXOC", NavMessageType::LXOC),
+        ] {
+            assert_eq!(NavMessageType::from_str(code).unwrap(), msgtype);
+            assert_eq!(msgtype.to_string(), code);
+        }
+        assert!(NavMessageType::from_str("LEG").is_err());
+    }
+
+    #[test]
+    fn message_subtype() {
+        for (code, subtype) in [
+            ("WIDE", NavMessageSubtype::WIDE),
+            ("JAPN", NavMessageSubtype::JAPN),
+            ("KLOB", NavMessageSubtype::KLOB),
+            ("NEQN", NavMessageSubtype::NEQN),
+        ] {
+            assert_eq!(NavMessageSubtype::from_str(code).unwrap(), subtype);
+            assert_eq!(subtype.to_string(), code);
+        }
+        assert!(NavMessageSubtype::from_str("").is_err());
+        assert!(NavMessageSubtype::from_str("LNAV").is_err());
     }
 }

--- a/src/navigation/mod.rs
+++ b/src/navigation/mod.rs
@@ -21,7 +21,7 @@ pub use crate::navigation::{
     frame::{NavFrame, NavFrameType},
     header::HeaderFields,
     ionosphere::{BdModel, IonosphereModel, KbModel, KbRegionCode, NgModel, NgRegionFlags},
-    message::NavMessageType,
+    message::{NavMessageSubtype, NavMessageType},
     time::TimeOffset,
 };
 
@@ -42,7 +42,16 @@ use serde::{Deserialize, Serialize};
 
 use std::collections::BTreeMap;
 
-use crate::prelude::{Epoch, SV};
+use crate::prelude::{Constellation, Epoch, ParsingError, TimeScale, SV};
+
+/// [TimeScale] of the navigation messages of a [Constellation].
+/// NavIC messages are expressed in GPST (RINEX 4.02 Table A30).
+pub(crate) fn timescale(constellation: Constellation) -> Result<TimeScale, ParsingError> {
+    match constellation {
+        Constellation::IRNSS => Ok(TimeScale::GPST),
+        c => c.timescale().ok_or(ParsingError::NoTimescaleDefinition),
+    }
+}
 
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -58,6 +67,10 @@ pub struct NavKey {
 
     /// [NavFrame] type following.
     pub frmtype: NavFrameType,
+
+    /// [NavMessageSubtype], optional fourth field of the RINEX 4.02
+    /// record header, telling apart otherwise identical records.
+    pub subtype: Option<NavMessageSubtype>,
 }
 
 /// Navigation data are [NavFrame]s indexed by [NavKey].

--- a/src/navigation/mod.rs
+++ b/src/navigation/mod.rs
@@ -20,7 +20,10 @@ pub use crate::navigation::{
     ephemeris::{flags::*, orbits::OrbitItem, Ephemeris},
     frame::{NavFrame, NavFrameType},
     header::HeaderFields,
-    ionosphere::{BdModel, IonosphereModel, KbModel, KbRegionCode, NgModel, NgRegionFlags},
+    ionosphere::{
+        BdModel, GloCdmaModel, IonosphereModel, KbModel, KbRegionCode, NavicKbModel,
+        NavicNeqnModel, NavicNeqnRegion, NgModel, NgRegionFlags,
+    },
     message::{NavMessageSubtype, NavMessageType},
     time::TimeOffset,
 };

--- a/src/navigation/parsing/mod.rs
+++ b/src/navigation/parsing/mod.rs
@@ -26,6 +26,7 @@ pub fn parse_epoch(header: &Header, content: &str) -> Result<(NavKey, NavFrame),
             sv,
             msgtype: NavMessageType::LNAV,
             frmtype: NavFrameType::Ephemeris,
+            subtype: None,
         };
 
         let frame = NavFrame::EPH(eph);
@@ -79,7 +80,7 @@ pub fn is_new_epoch(line: &str, v: Version) -> bool {
 
 #[cfg(test)]
 mod test {
-    use super::{is_new_epoch, parse_epoch};
+    use super::{is_new_epoch, parse_epoch, parse_v4_epoch};
 
     use crate::{
         navigation::{NavFrameType, NavMessageType},
@@ -456,5 +457,46 @@ mod test {
                 panic!("Got unexpected key \"{}\" for GLOV3 record", k);
             }
         }
+    }
+
+    #[test]
+    fn v4_record_header_line() {
+        use crate::navigation::{ionosphere::KbRegionCode, NavMessageSubtype};
+        use crate::prelude::{Constellation, SV};
+
+        // blank PRN: the record names the constellation only
+        let content = "> STO E   IFNV
+    2020 09 15 00 00 00 GAUT                                  UTCGAL
+     6.048000000000e+05-1.862645149231e-09 8.881784197001e-16 0.000000000000e+00";
+        let (k, _) = parse_v4_epoch(content).unwrap();
+        assert_eq!(k.sv, SV::new(Constellation::Galileo, 0));
+        assert_eq!(k.msgtype, NavMessageType::IFNV);
+        assert_eq!(k.subtype, None);
+        assert_eq!(k.epoch, Epoch::from_str("2020-09-15T00:00:00 GST").unwrap());
+
+        // RINEX 4.02 subtype: QZSS region code
+        let content = "> ION J01 CNVX JAPN
+    2022 06 08 09 59 48 1.024454832077E-08 2.235174179077E-08-5.960464477539E-08
+    -1.192092895508E-07 9.625600000000E+04 1.310720000000E+05-6.553600000000E+04
+    -5.898240000000E+05 0.000000000000E+00";
+        let (k, frame) = parse_v4_epoch(content).unwrap();
+        assert_eq!(k.subtype, Some(NavMessageSubtype::JAPN));
+        let model = frame.as_ionosphere_model().unwrap().as_klobuchar().unwrap();
+        assert_eq!(model.region, KbRegionCode::Japan);
+
+        // unknown subtype
+        let content = content.replace("JAPN", "WEST");
+        assert!(parse_v4_epoch(&content).is_err());
+
+        // NavIC records are expressed in GPST
+        let content = "> STO I02 LNAV
+    2020 09 15 02 05 36 IRUT
+     6.048000000000e+05 0.000000000000e+00 0.000000000000e+00 0.000000000000e+00";
+        let (k, _) = parse_v4_epoch(content).unwrap();
+        assert_eq!(k.msgtype, NavMessageType::LNAV);
+        assert_eq!(
+            k.epoch,
+            Epoch::from_str("2020-09-15T02:05:36 GPST").unwrap()
+        );
     }
 }

--- a/src/navigation/parsing/v4.rs
+++ b/src/navigation/parsing/v4.rs
@@ -1,7 +1,8 @@
 use crate::{
     navigation::{
-        timescale, BdModel, EarthOrientation, Ephemeris, IonosphereModel, KbModel, KbRegionCode,
-        NavFrame, NavFrameType, NavKey, NavMessageSubtype, NavMessageType, NgModel, TimeOffset,
+        timescale, BdModel, EarthOrientation, Ephemeris, GloCdmaModel, IonosphereModel, KbModel,
+        KbRegionCode, NavFrame, NavFrameType, NavKey, NavMessageSubtype, NavMessageType,
+        NavicKbModel, NavicNeqnModel, NgModel, TimeOffset,
     },
     prelude::{Constellation, Epoch, ParsingError, SV},
 };
@@ -58,6 +59,23 @@ pub fn parse(content: &str) -> Result<(NavKey, NavFrame), ParsingError> {
                 NavMessageType::IFNV => {
                     let (epoch, model) = NgModel::parse(lines, ts)?;
                     (epoch, IonosphereModel::NequickG(model))
+                },
+                // RINEX 4.02: NavIC L1NV models, told apart by the subtype
+                NavMessageType::L1NV => match subtype {
+                    Some(NavMessageSubtype::KLOB) => {
+                        let (epoch, model) = NavicKbModel::parse(lines, ts)?;
+                        (epoch, IonosphereModel::NavicKlobuchar(model))
+                    },
+                    Some(NavMessageSubtype::NEQN) => {
+                        let (epoch, model) = NavicNeqnModel::parse(lines, ts)?;
+                        (epoch, IonosphereModel::NavicNequick(model))
+                    },
+                    _ => return Err(ParsingError::NavMsgSubtype),
+                },
+                // RINEX 4.02: GLONASS CDMA model
+                NavMessageType::LXOC => {
+                    let (epoch, model) = GloCdmaModel::parse(lines, ts)?;
+                    (epoch, IonosphereModel::GlonassCdma(model))
                 },
                 NavMessageType::CNVX => match sv.constellation {
                     Constellation::BeiDou => {

--- a/src/navigation/parsing/v4.rs
+++ b/src/navigation/parsing/v4.rs
@@ -1,7 +1,7 @@
 use crate::{
     navigation::{
-        BdModel, EarthOrientation, Ephemeris, IonosphereModel, KbModel, NavFrame, NavFrameType,
-        NavKey, NavMessageType, NgModel, TimeOffset,
+        timescale, BdModel, EarthOrientation, Ephemeris, IonosphereModel, KbModel, KbRegionCode,
+        NavFrame, NavFrameType, NavKey, NavMessageSubtype, NavMessageType, NgModel, TimeOffset,
     },
     prelude::{Constellation, Epoch, ParsingError, SV},
 };
@@ -22,13 +22,30 @@ pub fn parse(content: &str) -> Result<(NavKey, NavFrame), ParsingError> {
 
     // frmtype defines message to follow
     let frmtype = class.trim().parse::<NavFrameType>()?;
-    let sv = svnn.trim().parse::<SV>()?;
-    let msgtype = rem.trim().parse::<NavMessageType>()?;
 
-    let ts = sv
-        .constellation
-        .timescale()
-        .ok_or(ParsingError::NoTimescaleDefinition)?;
+    // STO, EOP and ION records may name the constellation only
+    // (blank PRN): represented by PRN 0.
+    let svnn = svnn.trim();
+    let sv = if svnn.len() == 1 {
+        SV::new(svnn.parse::<Constellation>()?, 0)
+    } else {
+        svnn.parse::<SV>()?
+    };
+
+    // message type, followed by an optional subtype (RINEX 4.02)
+    let mut items = rem.split_ascii_whitespace();
+
+    let msgtype = items
+        .next()
+        .ok_or(ParsingError::NavMsgType)?
+        .parse::<NavMessageType>()?;
+
+    let subtype = match items.next() {
+        Some(item) => Some(item.parse::<NavMessageSubtype>()?),
+        None => None,
+    };
+
+    let ts = timescale(sv.constellation)?;
 
     // Parses navframe type dependent and epoch of publication
     let (epoch, fr) = match frmtype {
@@ -48,7 +65,13 @@ pub fn parse(content: &str) -> Result<(NavKey, NavFrame), ParsingError> {
                         (epoch, IonosphereModel::Bdgim(model))
                     },
                     _ => {
-                        let (epoch, model) = KbModel::parse(lines, ts)?;
+                        let (epoch, mut model) = KbModel::parse(lines, ts)?;
+                        // RINEX 4.02: QZSS region code moved to the subtype field
+                        match subtype {
+                            Some(NavMessageSubtype::WIDE) => model.region = KbRegionCode::Worldwide,
+                            Some(NavMessageSubtype::JAPN) => model.region = KbRegionCode::Japan,
+                            _ => {},
+                        }
                         (epoch, IonosphereModel::Klobuchar(model))
                     },
                 },
@@ -85,6 +108,7 @@ pub fn parse(content: &str) -> Result<(NavKey, NavFrame), ParsingError> {
         sv,
         msgtype,
         frmtype,
+        subtype,
     };
 
     Ok((key, fr))

--- a/src/navigation/time/formatting.rs
+++ b/src/navigation/time/formatting.rs
@@ -90,7 +90,9 @@ impl TimeOffset {
             fmt_rinex(
                 &format!(
                     "{} {}{} {:6}{:5}",
-                    self.to_lhs_rhs_timescales(),
+                    self.time_system
+                        .as_deref()
+                        .unwrap_or_else(|| self.to_lhs_rhs_timescales()),
                     NavFormatter::new_time_system_correction_v3_offset(self.polynomial.0),
                     NavFormatter::new_time_system_correction_v3_drift(self.polynomial.1),
                     self.t_ref.1 / 1_000_000_000,
@@ -113,7 +115,9 @@ impl TimeOffset {
             w,
             "    {} {}",
             format_epoch_v4_fields(t),
-            self.to_lhs_rhs_timescales(),
+            self.time_system
+                .as_deref()
+                .unwrap_or_else(|| self.to_lhs_rhs_timescales()),
         )?;
 
         // UTC identifier, column 63

--- a/src/navigation/time/mod.rs
+++ b/src/navigation/time/mod.rs
@@ -29,6 +29,11 @@ pub struct TimeOffset {
     /// Possible UTC ID# in case this came from RINEXv4
     pub utc: Option<String>,
 
+    /// Four letter time system pair as read from the file ("GPUT",
+    /// "GLUT", ...). Pairs without an exact [TimeScale] representation
+    /// (GLONASS and NavIC times) keep their identity here.
+    pub time_system: Option<String>,
+
     /// Interpolation polynomial
     pub polynomial: (f64, f64, f64),
 }
@@ -47,6 +52,7 @@ impl TimeOffset {
             rhs,
             t_ref,
             utc: None,
+            time_system: None,
             polynomial,
         }
     }
@@ -63,6 +69,7 @@ impl TimeOffset {
             lhs,
             rhs,
             utc: None,
+            time_system: None,
             polynomial,
             t_ref: (t_week, t_nanos),
         }

--- a/src/navigation/time/parsing.rs
+++ b/src/navigation/time/parsing.rs
@@ -25,6 +25,14 @@ impl TimeOffset {
             "BDGP" => Ok((TimeScale::BDT, TimeScale::GPST)),
             // "SBAS"
             "SBUT" => Ok((TimeScale::GPST, TimeScale::UTC)),
+            // GLONASS: no dedicated TimeScale, UTC(SU) based
+            "GLUT" => Ok((TimeScale::UTC, TimeScale::UTC)),
+            "GLGP" => Ok((TimeScale::UTC, TimeScale::GPST)),
+            // NavIC: GPST aligned
+            "IRUT" => Ok((TimeScale::GPST, TimeScale::UTC)),
+            "IRGP" => Ok((TimeScale::GPST, TimeScale::GPST)),
+            // beidou / glonass
+            "BDGL" => Ok((TimeScale::BDT, TimeScale::UTC)),
             _ => Err(ParsingError::NavInvalidTimescale),
         }
     }
@@ -117,13 +125,10 @@ impl TimeOffset {
 
         let a1 = parse_f64(a1.trim()).map_err(|_| ParsingError::NavTimeOffsetParinsg)?;
 
-        Ok(Self::from_time_of_week(
-            week,
-            seconds * 1_000_000_000,
-            lhs,
-            rhs,
-            (a0, a1, 0.0),
-        ))
+        let mut time_offset =
+            Self::from_time_of_week(week, seconds * 1_000_000_000, lhs, rhs, (a0, a1, 0.0));
+        time_offset.time_system = Some(timescales.trim().to_string());
+        Ok(time_offset)
     }
 
     /// Parse [TimeOffset] from RINEXv4 standard
@@ -161,6 +166,7 @@ impl TimeOffset {
 
         let mut time_offset = Self::from_time_of_week(t_week, t_nanos, lhs, rhs, (a0, a1, a2));
         time_offset.utc = utc;
+        time_offset.time_system = Some(timescales.to_string());
 
         Ok(time_offset)
     }
@@ -297,6 +303,12 @@ mod test {
             let expected =
                 TimeOffset::from_time_of_week(week, sec * 1_000_000_000, lhs, rhs, (a0, a1, 0.0));
 
+            let expected = TimeOffset {
+                time_system: Some(content[..4].to_string()),
+
+                ..expected
+            };
+
             let parsed = TimeOffset::parse_v3(content).unwrap();
 
             assert_eq!(parsed, expected);
@@ -368,6 +380,63 @@ mod test {
                     panic!("two lines expected (only)!");
                 }
             }
+        }
+    }
+
+    #[test]
+    fn parsing_v4_time_systems() {
+        // RINEX 4.02 pairs without a dedicated hifitime TimeScale keep
+        // their four letter code, and every pair writes back as read
+        let line_2 =
+            "     5.184000000000e+05 1.862645149231e-09 8.881784197001e-16 0.000000000000e+00";
+
+        for (line_1, code, lhs, rhs) in [
+            (
+                "    2024 02 03 00 00 00 GLUT                                  UTC(SU)           ",
+                "GLUT",
+                TimeScale::UTC,
+                TimeScale::UTC,
+            ),
+            (
+                "    2024 02 03 00 00 00 GLGP",
+                "GLGP",
+                TimeScale::UTC,
+                TimeScale::GPST,
+            ),
+            (
+                "    2023 06 24 00 00 00 IRUT",
+                "IRUT",
+                TimeScale::GPST,
+                TimeScale::UTC,
+            ),
+            (
+                "    2023 06 24 00 00 00 IRGP",
+                "IRGP",
+                TimeScale::GPST,
+                TimeScale::GPST,
+            ),
+            (
+                "    2021 07 05 23 20 00 BDGL",
+                "BDGL",
+                TimeScale::BDT,
+                TimeScale::UTC,
+            ),
+            (
+                "    2020 09 18 19 56 30 GPUT",
+                "GPUT",
+                TimeScale::GPST,
+                TimeScale::UTC,
+            ),
+        ] {
+            let parsed = TimeOffset::parse_v4(line_1, line_2).unwrap();
+            assert_eq!(parsed.lhs, lhs, "{}", code);
+            assert_eq!(parsed.rhs, rhs, "{}", code);
+            assert_eq!(parsed.time_system.as_deref(), Some(code));
+
+            let mut buf = BufWriter::new(Utf8Buffer::new(256));
+            parsed.format_v4(&mut buf).unwrap();
+            let content = buf.into_inner().unwrap().to_ascii_utf8();
+            assert_eq!(&content[..28], &line_1[..28]);
         }
     }
 }

--- a/src/observation/parsing.rs
+++ b/src/observation/parsing.rs
@@ -249,6 +249,12 @@ fn parse_signals_v2(
         let sv_end = (sv_ptr + SVNN_SIZE).min(systems_str_len);
         let system = systems_str[sv_ptr..sv_end].trim();
 
+        if system.is_empty() {
+            // blank slot: fewer than twelve vehicles on a line that
+            // carries a clock offset
+            break;
+        }
+
         let mut sv = SV::default();
         if let Ok(found) = SV::from_str(system) {
             sv = found;

--- a/src/tests/formatting/nav.rs
+++ b/src/tests/formatting/nav.rs
@@ -48,18 +48,24 @@ fn v4_record_blocks(content: &str) -> HashMap<String, Vec<String>> {
 /// each other in the record, so the original file may hold more.
 fn v4_records_write_back(name: &str) {
     let path = format!("data/NAV/V4/{}", name);
-    let original = Rinex::from_gzip_file(&path).unwrap();
+    let original = if name.ends_with(".gz") {
+        Rinex::from_gzip_file(&path).unwrap()
+    } else {
+        Rinex::from_file(&path).unwrap()
+    };
 
     let tmp = format!("test-{}.rnx", name);
     original.to_file(&tmp).unwrap();
     let written = read_to_string(&tmp).unwrap();
     let _ = remove_file(&tmp);
 
-    let original_text = {
+    let original_text = if name.ends_with(".gz") {
         let mut reader = flate2::read::GzDecoder::new(std::fs::File::open(&path).unwrap());
         let mut content = String::new();
         std::io::Read::read_to_string(&mut reader, &mut content).unwrap();
         content
+    } else {
+        read_to_string(&path).unwrap()
     };
 
     let model = v4_record_blocks(&original_text);
@@ -118,4 +124,11 @@ fn nav_v4_kms300dnk_records_write_back() {
 #[test]
 fn nav_v4_brd400dlr_records_write_back() {
     v4_records_write_back("BRD400DLR_S_20230710000_01D_MN.rnx.gz");
+}
+
+/// RINEX 4.02 specification examples: NavIC and GLONASS CDMA ION
+/// records, STO records with the new time system pairs and blank PRNs.
+#[test]
+fn nav_v4_02_examples_records_write_back() {
+    v4_records_write_back("rinex402_examples_MN.rnx");
 }

--- a/src/tests/formatting/nav.rs
+++ b/src/tests/formatting/nav.rs
@@ -332,3 +332,29 @@ fn nav_v3_mixed_written_as_v2_gps() {
         assert_ephemeris_preserved(&original[k], frame, k);
     }
 }
+
+/// Nothing representable in the target revision is an error, not an
+/// empty file: a RINEX 4 record reduced to its modern messages cannot
+/// be written as RINEX 3.
+#[test]
+fn nav_nothing_representable_is_an_error() {
+    let mut rinex =
+        Rinex::from_gzip_file("data/NAV/V4/BRD400DLR_S_20230710000_01D_MN.rnx.gz").unwrap();
+    rinex
+        .record
+        .as_mut_nav()
+        .unwrap()
+        .retain(|k, _| matches!(k.msgtype, NavMessageType::CNAV | NavMessageType::CNV2));
+    assert!(!rinex.record.as_nav().unwrap().is_empty());
+
+    rinex.header.version = Version::new(3, 5);
+    let result = write_and_reparse(&rinex, "cnav-as-v3");
+    assert!(
+        matches!(
+            result,
+            Err(crate::error::FormattingError::NoRepresentableFrame)
+        ),
+        "{:?}",
+        result.map(|_| ())
+    );
+}

--- a/src/tests/formatting/nav.rs
+++ b/src/tests/formatting/nav.rs
@@ -132,3 +132,203 @@ fn nav_v4_brd400dlr_records_write_back() {
 fn nav_v4_02_examples_records_write_back() {
     v4_records_write_back("rinex402_examples_MN.rnx");
 }
+
+use crate::{
+    navigation::{NavFrame, NavKey, NavMessageType},
+    prelude::{Constellation, Version},
+};
+
+/// Writes `rinex` in the revision of its (modified) header to a
+/// temporary file and parses it back.
+fn write_and_reparse(rinex: &Rinex, tag: &str) -> Result<Rinex, crate::error::FormattingError> {
+    let tmp = format!("test-{}-{}.rnx", tag, std::process::id());
+    rinex.to_file(&tmp)?;
+    let parsed = Rinex::from_file(&tmp).unwrap();
+    let _ = remove_file(&tmp);
+    Ok(parsed)
+}
+
+/// The ephemeris written in another revision must carry the values of
+/// the original: same clock fields, every orbit field of the reparsed
+/// record equal to the original's (the RINEX 3 definitions may omit
+/// fields of the RINEX 4 messages, and name the BeiDou group delays
+/// differently).
+fn assert_ephemeris_preserved(original: &NavFrame, reparsed: &NavFrame, k: &NavKey) {
+    let (a, b) = (
+        original.as_ephemeris().unwrap(),
+        reparsed.as_ephemeris().unwrap(),
+    );
+    assert_eq!(a.clock_bias, b.clock_bias, "clock bias {:?}", k);
+    assert_eq!(a.clock_drift, b.clock_drift, "clock drift {:?}", k);
+    assert_eq!(
+        a.clock_drift_rate, b.clock_drift_rate,
+        "clock drift rate {:?}",
+        k
+    );
+
+    fn alias(name: &str) -> &str {
+        match name {
+            "tgdb1b3" => "tgd1b1b3",
+            "tgdb2b3" => "tgd2b2b3",
+            "tgd1b1b3" => "tgdb1b3",
+            "tgd2b2b3" => "tgdb2b3",
+            other => other,
+        }
+    }
+
+    assert!(!b.orbits.is_empty(), "no orbit field at {:?}", k);
+    for (name, value) in b.orbits.iter() {
+        let expected = a
+            .orbits
+            .get(name)
+            .or_else(|| a.orbits.get(alias(name)))
+            .unwrap_or_else(|| {
+                panic!("{} written at {:?} does not exist in the original", name, k)
+            });
+        assert_eq!(
+            value.as_f64(),
+            expected.as_f64(),
+            "{} differs at {:?}",
+            name,
+            k
+        );
+    }
+}
+
+/// A RINEX 4 file mixing modern (CNAV, CNV1 to CNV3) and legacy messages
+/// written as RINEX 3 keeps every legacy ephemeris, and only those: one
+/// unrepresentable frame must not abort the whole file.
+#[test]
+fn nav_v4_written_as_v3_keeps_the_legacy_ephemerides() {
+    for name in [
+        "KMS300DNK_R_20221591000_01H_MN.rnx.gz",
+        "BRD400DLR_S_20230710000_01D_MN.rnx.gz",
+    ] {
+        let mut rinex = Rinex::from_gzip_file(&format!("data/NAV/V4/{}", name)).unwrap();
+        let original = rinex.record.as_nav().unwrap().clone();
+
+        let legacy = original
+            .iter()
+            .filter(|(k, v)| v.as_ephemeris().is_some() && k.msgtype.is_legacy(k.sv.constellation))
+            .collect::<Vec<_>>();
+        let modern = original
+            .iter()
+            .filter(|(k, v)| v.as_ephemeris().is_some() && !k.msgtype.is_legacy(k.sv.constellation))
+            .count();
+        // BRD400DLR mixes LNAV with CNAV and CNV1 to CNV3
+        if name.starts_with("BRD400DLR") {
+            assert!(modern > 0, "{} carries no modern message", name);
+        }
+
+        // records sharing epoch and vehicle collapse to one RINEX 3 key
+        let expected = legacy
+            .iter()
+            .map(|(k, _)| (k.epoch, k.sv))
+            .collect::<std::collections::BTreeSet<_>>()
+            .len();
+
+        rinex.header.version = Version::new(3, 5);
+        let parsed = write_and_reparse(&rinex, "v4-as-v3").unwrap();
+        assert_eq!(parsed.header.version, Version::new(3, 5));
+
+        let record = parsed.record.as_nav().unwrap();
+        assert_eq!(record.len(), expected, "{}", name);
+
+        for (k, frame) in record.iter() {
+            assert_eq!(k.msgtype, NavMessageType::LNAV);
+            // the last legacy message of this epoch and vehicle was written
+            let (_, original) = legacy
+                .iter()
+                .filter(|(o, _)| o.epoch == k.epoch && o.sv == k.sv)
+                .last()
+                .unwrap_or_else(|| panic!("{:?} was not in the original file", k));
+            assert_ephemeris_preserved(original, frame, k);
+        }
+    }
+}
+
+/// A RINEX 3 file written as RINEX 4 gets the message type of each
+/// constellation, and written back as RINEX 3 gives the original record.
+#[test]
+fn nav_v3_written_as_v4_gets_message_types() {
+    let mut rinex = Rinex::from_file("data/NAV/V3/AMEL00NLD_R_20210010000_01D_MN.rnx").unwrap();
+    let original = rinex.record.as_nav().unwrap().clone();
+
+    rinex.header.version = Version::new(4, 0);
+    let parsed = write_and_reparse(&rinex, "v3-as-v4").unwrap();
+
+    let record = parsed.record.as_nav().unwrap();
+    assert_eq!(record.len(), original.len());
+
+    let mut seen = std::collections::BTreeSet::new();
+    for (k, frame) in record.iter() {
+        let expected = match k.sv.constellation {
+            Constellation::GPS => NavMessageType::LNAV,
+            Constellation::Glonass => NavMessageType::FDMA,
+            Constellation::Galileo => {
+                let source = frame
+                    .as_ephemeris()
+                    .unwrap()
+                    .get_orbit_f64("source")
+                    .unwrap_or(0.0) as u32;
+                if source & 0x02 != 0 {
+                    NavMessageType::FNAV
+                } else {
+                    NavMessageType::INAV
+                }
+            },
+            Constellation::BeiDou => {
+                if k.sv.prn <= 5 || k.sv.prn >= 59 {
+                    NavMessageType::D2
+                } else {
+                    NavMessageType::D1
+                }
+            },
+            c if c.is_sbas() => NavMessageType::SBAS,
+            _ => NavMessageType::LNAV,
+        };
+        assert_eq!(k.msgtype, expected, "{:?}", k);
+        seen.insert(k.sv.constellation);
+
+        let key = NavKey {
+            msgtype: NavMessageType::LNAV,
+            ..*k
+        };
+        let original = original
+            .get(&key)
+            .unwrap_or_else(|| panic!("{:?} not found", key));
+        assert_ephemeris_preserved(original, frame, k);
+    }
+    assert!(seen.contains(&Constellation::Glonass) && seen.contains(&Constellation::BeiDou));
+
+    // and back
+    let mut parsed = parsed;
+    parsed.header.version = Version::new(3, 5);
+    let back = write_and_reparse(&parsed, "v4-back-as-v3").unwrap();
+    assert_eq!(back.record.as_nav().unwrap(), &original);
+}
+
+/// A mixed RINEX 3 file written as a RINEX 2 GPS file keeps the GPS
+/// ephemerides only.
+#[test]
+fn nav_v3_mixed_written_as_v2_gps() {
+    let mut rinex = Rinex::from_file("data/NAV/V3/CBW100NLD_R_20210010000_01D_MN.rnx").unwrap();
+    let original = rinex.record.as_nav().unwrap().clone();
+
+    let gps = original
+        .iter()
+        .filter(|(k, _)| k.sv.constellation == Constellation::GPS)
+        .count();
+    assert!(gps > 0 && gps < original.len());
+
+    rinex.header.version = Version::new(2, 11);
+    rinex.header.constellation = Some(Constellation::GPS);
+    let parsed = write_and_reparse(&rinex, "v3-as-v2").unwrap();
+
+    let record = parsed.record.as_nav().unwrap();
+    assert_eq!(record.len(), gps);
+    for (k, frame) in record.iter() {
+        assert_eq!(k.sv.constellation, Constellation::GPS);
+        assert_ephemeris_preserved(&original[k], frame, k);
+    }
+}

--- a/src/tests/formatting/nav.rs
+++ b/src/tests/formatting/nav.rs
@@ -247,6 +247,44 @@ fn nav_v4_written_as_v3_keeps_the_legacy_ephemerides() {
     }
 }
 
+/// The rinexfetch use case: the rapid BRD400DLR product filtered to GPS
+/// (LNAV, CNAV and CNV2 messages) written as RINEX 3 keeps every LNAV
+/// ephemeris, the modern messages have no RINEX 3 representation.
+#[test]
+fn nav_v4_gps_only_written_as_v3() {
+    let mut rinex =
+        Rinex::from_gzip_file("data/NAV/V4/BRD400DLR_S_20230710000_01D_MN.rnx.gz").unwrap();
+    rinex
+        .record
+        .as_mut_nav()
+        .unwrap()
+        .retain(|k, _| k.sv.constellation == Constellation::GPS);
+
+    let original = rinex.record.as_nav().unwrap().clone();
+    let lnav = original
+        .iter()
+        .filter(|(k, v)| v.as_ephemeris().is_some() && k.msgtype == NavMessageType::LNAV)
+        .collect::<Vec<_>>();
+    let modern = original
+        .iter()
+        .filter(|(k, v)| v.as_ephemeris().is_some() && k.msgtype != NavMessageType::LNAV)
+        .count();
+    assert!(!lnav.is_empty() && modern > 0);
+
+    rinex.header.version = Version::new(3, 5);
+    let parsed = write_and_reparse(&rinex, "gps-as-v3").unwrap();
+
+    let record = parsed.record.as_nav().unwrap();
+    assert_eq!(record.len(), lnav.len());
+    for (k, frame) in record.iter() {
+        let (_, original) = lnav
+            .iter()
+            .find(|(o, _)| o.epoch == k.epoch && o.sv == k.sv)
+            .unwrap_or_else(|| panic!("{:?} was not in the original file", k));
+        assert_ephemeris_preserved(original, frame, k);
+    }
+}
+
 /// A RINEX 3 file written as RINEX 4 gets the message type of each
 /// constellation, and written back as RINEX 3 gives the original record.
 #[test]

--- a/src/tests/nav.rs
+++ b/src/tests/nav.rs
@@ -1,6 +1,6 @@
 use crate::{
     navigation::{NavFrameType, NavMessageType},
-    prelude::{Constellation, Epoch, Rinex, TimeScale, SV},
+    prelude::{Constellation, Epoch, Rinex, TimeScale, Version, SV},
     tests::toolkit::{generic_navigation_test, TimeFrame},
 };
 
@@ -1381,4 +1381,142 @@ fn nav_v2_iono_alphabeta_and_toe() {
     //     //     );
     //     // }
     // }
+}
+
+/// RINEX 4.02 specification examples (Tables A12, A18, A32 and A41)
+/// gathered in a single 4.02 file.
+#[test]
+fn nav_v4_02_spec_examples() {
+    use crate::navigation::{NavFrameType, NavMessageSubtype, NavMessageType};
+
+    let dut = Rinex::from_file("data/NAV/V4/rinex402_examples_MN.rnx").unwrap();
+    assert_eq!(dut.header.version, Version::new(4, 2));
+
+    let record = dut.record.as_nav().unwrap();
+
+    // records sharing epoch, satellite, message type and subtype
+    // share a key: the file has 34 records for 30 keys.
+    let count = |frmtype: NavFrameType| record.keys().filter(|k| k.frmtype == frmtype).count();
+    assert_eq!(count(NavFrameType::Ephemeris), 9);
+    assert_eq!(count(NavFrameType::SystemTimeOffset), 9);
+    assert_eq!(count(NavFrameType::EarthOrientation), 5);
+    assert_eq!(count(NavFrameType::IonosphereModel), 7);
+
+    let find = |frmtype: NavFrameType, sv: &str, msgtype: NavMessageType| {
+        let sv = SV::from_str(sv).unwrap();
+        record
+            .iter()
+            .find(|(k, _)| k.frmtype == frmtype && k.sv == sv && k.msgtype == msgtype)
+            .unwrap_or_else(|| panic!("{} {:x} {} not found", frmtype, sv, msgtype))
+    };
+
+    // GPS (Table A12)
+    let (_, eph) = find(NavFrameType::Ephemeris, "G04", NavMessageType::CNV2);
+    let eph = eph.as_ephemeris().unwrap();
+    assert_eq!(eph.get_orbit_f64("iscL1Cd"), Some(-3.492459654808e-10));
+    assert_eq!(eph.get_orbit_f64("t_tm"), Some(3.550860000000e+05));
+    assert_eq!(eph.get_orbit_f64("wn_op"), Some(2044.0));
+
+    // GLONASS (Table A18)
+    let (k, _) = find(NavFrameType::Ephemeris, "R01", NavMessageType::FDMA);
+    assert_eq!(k.epoch, Epoch::from_str("2020-09-15T23:45:00 UTC").unwrap());
+    for msgtype in [NavMessageType::L1OC, NavMessageType::L3OC] {
+        let (k, eph) = find(NavFrameType::Ephemeris, "R26", msgtype);
+        assert_eq!(k.epoch, Epoch::from_str("2024-02-03T00:15:00 UTC").unwrap());
+        let eph = eph.as_ephemeris().unwrap();
+        assert_eq!(eph.get_orbit_f64("satPosX"), Some(1.812154053020e+04));
+        assert_eq!(eph.get_orbit_f64("t_tm"), Some(5.184000000000e+05));
+    }
+
+    // NavIC (Table A32), in GPST
+    let epochs = record
+        .keys()
+        .filter(|k| k.sv == SV::from_str("I02").unwrap() && k.frmtype == NavFrameType::Ephemeris)
+        .map(|k| k.epoch)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        epochs,
+        vec![
+            Epoch::from_str("2020-09-15T02:05:36 GPST").unwrap(),
+            Epoch::from_str("2020-09-15T02:20:48 GPST").unwrap(),
+        ]
+    );
+    let (k, eph) = find(NavFrameType::Ephemeris, "I10", NavMessageType::L1NV);
+    assert_eq!(
+        k.epoch,
+        Epoch::from_str("2023-06-24T00:05:00 GPST").unwrap()
+    );
+    let eph = eph.as_ephemeris().unwrap();
+    assert_eq!(eph.get_orbit_f64("rsf"), Some(1.0));
+    assert_eq!(eph.get_orbit_f64("tgdSL5"), Some(-3.608874976635e-09));
+
+    // STO (Table A41): blank PRN, UTC identifier, new time system pairs
+    let (k, sto) = find(NavFrameType::SystemTimeOffset, "E00", NavMessageType::IFNV);
+    assert_eq!(k.epoch, Epoch::from_str("2020-09-15T00:00:00 GST").unwrap());
+    let sto = sto.as_system_time().unwrap();
+    assert_eq!(sto.time_system.as_deref(), Some("GAUT"));
+    assert_eq!(sto.utc.as_deref(), Some("UTCGAL"));
+    let (_, sto) = find(NavFrameType::SystemTimeOffset, "I10", NavMessageType::L1NV);
+    assert_eq!(
+        sto.as_system_time().unwrap().time_system.as_deref(),
+        Some("IRUT")
+    );
+    let (_, sto) = find(NavFrameType::SystemTimeOffset, "R26", NavMessageType::LXOC);
+    assert_eq!(
+        sto.as_system_time().unwrap().time_system.as_deref(),
+        Some("GLUT")
+    );
+
+    // EOP (Table A41)
+    let (k, eop) = find(NavFrameType::EarthOrientation, "I10", NavMessageType::L1NV);
+    assert_eq!(
+        k.epoch,
+        Epoch::from_str("2023-06-24T00:04:48 GPST").unwrap()
+    );
+    let eop = eop.as_earth_orientation().unwrap();
+    assert_eq!(eop.x.0, 1.616811752319e-01);
+    assert_eq!(eop.t_tm, 519426);
+    let (_, eop) = find(NavFrameType::EarthOrientation, "R04", NavMessageType::LXOC);
+    assert_eq!(eop.as_earth_orientation().unwrap().t_tm, 518394);
+
+    // ION (Table A41)
+    let (_, ion) = find(NavFrameType::IonosphereModel, "G14", NavMessageType::CNVX);
+    assert!(ion.as_ionosphere_model().unwrap().as_klobuchar().is_some());
+    let (_, ion) = find(NavFrameType::IonosphereModel, "E13", NavMessageType::IFNV);
+    assert_eq!(
+        ion.as_ionosphere_model()
+            .unwrap()
+            .as_nequick_g()
+            .unwrap()
+            .a
+            .0,
+        54.5
+    );
+    let (_, ion) = find(NavFrameType::IonosphereModel, "C03", NavMessageType::D1D2);
+    assert!(ion.as_ionosphere_model().unwrap().as_klobuchar().is_some());
+
+    // NavIC KLOB and NEQN share everything but the subtype
+    let i10 = SV::from_str("I10").unwrap();
+    let mut subtypes = record
+        .iter()
+        .filter(|(k, _)| k.frmtype == NavFrameType::IonosphereModel && k.sv == i10)
+        .map(|(k, v)| (k.subtype, v.as_ionosphere_model().unwrap()))
+        .collect::<Vec<_>>();
+    subtypes.sort_by_key(|(subtype, _)| *subtype);
+    assert_eq!(subtypes.len(), 2);
+    assert_eq!(subtypes[0].0, Some(NavMessageSubtype::KLOB));
+    assert_eq!(subtypes[0].1.as_navic_klobuchar().unwrap().iodk, 1.0);
+    assert_eq!(subtypes[1].0, Some(NavMessageSubtype::NEQN));
+    assert_eq!(
+        subtypes[1].1.as_navic_nequick().unwrap().regions[1].a.0,
+        208.5
+    );
+
+    let (_, ion) = find(NavFrameType::IonosphereModel, "R22", NavMessageType::LXOC);
+    let ion = ion
+        .as_ionosphere_model()
+        .unwrap()
+        .as_glonass_cdma()
+        .unwrap();
+    assert_eq!(ion.c_f107, 141.0);
 }

--- a/src/tests/obs.rs
+++ b/src/tests/obs.rs
@@ -636,3 +636,19 @@ fn obs_null_substract() {
         generic_null_rinex_test(&diffed);
     }
 }
+
+mod v2_clock_offset {
+    use crate::prelude::Rinex;
+
+    /// RINEX 2 epoch line with fewer than twelve vehicles and a receiver
+    /// clock offset: the SV slots between the list and the offset are
+    /// blank and must not reach the SV parser (which panics on an empty
+    /// string).
+    #[test]
+    fn v2_epoch_line_with_clock_offset() {
+        let rinex = Rinex::from_file("data/OBS/V2/delf0010_clock.21o").unwrap();
+        assert_eq!(rinex.epoch_iter().count(), 24);
+        assert_eq!(rinex.sv_iter().count(), 3);
+        assert_eq!(rinex.signal_observations_iter().count(), 24 * 3 * 7);
+    }
+}


### PR DESCRIPTION
> **WARNING: this PR MUST be merged AFTER #443.** It is stacked on `m3/rinex-4.02-navigation`: the ten commits of #443 show in the diff until it merges, only the last four commits belong here.

## Summary

Writing a navigation record in a revision other than the parsed one failed or mislabeled the messages. Reproduced on `main`:

- both RINEX 4 files of the data folder written as 3.05 fail with `MissingNavigationStandards`: the first CNAV record aborts the whole file, taking every legacy ephemeris with it. The rapid multi-GNSS products (BRD400DLR) mix GPS LNAV with CNAV and CNV2, so a GPS-only downconversion to RINEX 3 was impossible;
- a RINEX 3 file written as 4.00 files every ephemeris as `LNAV` (`> EPH R19 LNAV`, `> EPH C05 LNAV`).

Four commits (the develop counterparts of the last three were part of #438):

- `navigation: tell the legacy messages from the RINEX 4 only ones`: `NavMessageType::is_legacy(constellation)`, the predicate the writer and the tests share: the legacy message of each constellation (LNAV, FDMA for GLONASS, INAV/FNAV for Galileo, D1/D2 for BeiDou, SBAS for SBAS vehicles) has a RINEX 2/3 representation, the modern messages and the STO, EOP and ION types do not. Public, since a user filtering a record before a downconversion needs the same rule.
- `navigation: write records in a revision other than the parsed one`: written as RINEX 2 or 3, keep the ephemerides of the legacy messages laid out with the RINEX 3 definitions, skip the modern messages (CNAV, CNV1 to CNV3, L1NV, L1OC, L3OC), the STO, EOP and ION records, and the satellites of other constellations in a single constellation RINEX 2 file. Written as RINEX 4, give the ephemerides parsed from RINEX 2 or 3 their message type: FDMA for GLONASS, SBAS for SBAS, INAV or FNAV for Galileo from the data source (Table A13), D1 or D2 for BeiDou from the GEO PRN range (BDS ICD). The BeiDou group delays, named differently by the RINEX 3 and 4 definitions, are written under either name.
- `navigation: fail when no frame can be written in the target revision`: `FormattingError::NoRepresentableFrame` when the record is not empty and none of its frames is representable, instead of a file with a header and no record.
- `tests: cover the GPS only RINEX 4 to 3 navigation conversion`: the BRD400DLR product filtered to GPS.

## Test plan

- KMS300DNK and BRD400DLR written as 3.05 keep exactly their legacy ephemerides, each field equal to the RINEX 4 value (records sharing epoch and vehicle, such as Galileo INAV/FNAV pairs, collapse to one RINEX 3 key: known limitation of the RINEX 3 layout).
- BRD400DLR filtered to GPS written as 3.05: every LNAV ephemeris kept, CNAV and CNV2 dropped.
- AMEL (RINEX 3) written as 4.00 gets the expected message types with every field preserved, and written back as 3.05 gives the original record. CBW (mixed RINEX 3) written as a 2.11 GPS file keeps the GPS ephemerides only. A record reduced to CNAV/CNV2 messages written as 3.05 returns `NoRepresentableFrame`.
- Unit test of `is_legacy` over every message type.
- `cargo test --all-features` green at every commit (240 to 245 tests).
- Checked with the rinexfetch tool (MrCry0/rinexfetch, `fix/nav-writer-negative-field-indent`) built against this branch: its GPS-only RINEX 3 output of the BRD400DLR product now succeeds (428 ephemerides), where it hit `MissingNavigationStandards` before.

## Notes

- New `FormattingError::NoRepresentableFrame` variant and `NavMessageType::is_legacy` method.

